### PR TITLE
fix: add /bin/sh to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,12 +7,10 @@ COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
 
-RUN go get github.com/otiai10/gosseract/v2
-
 ARG SERVICE_NAME TARGETOS TARGETARCH
-RUN --mount=target=. --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/go/pkg GOOS=$TARGETOS GOARCH=$TARGETARCH CGO_ENABLED=0 go build -tags=ocr -o /${SERVICE_NAME} ./cmd/main
-RUN --mount=target=. --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/go/pkg GOOS=$TARGETOS GOARCH=$TARGETARCH CGO_ENABLED=0 go build -tags=ocr -o /${SERVICE_NAME}-worker ./cmd/worker
-RUN --mount=target=. --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/go/pkg GOOS=$TARGETOS GOARCH=$TARGETARCH go build -o /${SERVICE_NAME}-migrate ./cmd/migration
+RUN --mount=target=. --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/go/pkg GOOS=$TARGETOS GOARCH=$TARGETARCH CGO_ENABLED=0 go build -o /${SERVICE_NAME} ./cmd/main
+RUN --mount=target=. --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/go/pkg GOOS=$TARGETOS GOARCH=$TARGETARCH CGO_ENABLED=0 go build -o /${SERVICE_NAME}-migrate ./cmd/migration
+RUN --mount=target=. --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/go/pkg GOOS=$TARGETOS GOARCH=$TARGETARCH CGO_ENABLED=0 go build -o /${SERVICE_NAME}-worker ./cmd/worker
 
 FROM gcr.io/distroless/base:nonroot
 
@@ -22,8 +20,13 @@ ARG SERVICE_NAME
 
 WORKDIR /${SERVICE_NAME}
 
+COPY --from=busybox:stable-musl --chown=nonroot:nonroot /bin/sh /bin/sh
+COPY --from=busybox:stable-musl --chown=nonroot:nonroot /bin/wget /bin/wget
+
 COPY --from=build --chown=nonroot:nonroot /src/config ./config
 COPY --from=build --chown=nonroot:nonroot /src/release-please ./release-please
+COPY --from=build --chown=nonroot:nonroot /src/pkg/db/migration ./pkg/db/migration
 
 COPY --from=build --chown=nonroot:nonroot /${SERVICE_NAME} ./
+COPY --from=build --chown=nonroot:nonroot /${SERVICE_NAME}-migrate ./
 COPY --from=build --chown=nonroot:nonroot /${SERVICE_NAME}-worker ./


### PR DESCRIPTION
Because

- `docker compose  up` from `instill-core` produces an error 

```sh
Error response from daemon: failed to create task for container: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: exec: "/bin/sh": stat /bin/sh: no such file or directory: unknown
make: *** [latest] Error 1
```

This commit

- Corrects `Dockerfile`. It had originally been copied from `mgmt-backend` but then adjusted based on other services. This commit reconciles the build strategy.
