### PR TITLE
feat: use dind in Dockerfile

### DIFF
--- a/.env
+++ b/.env
@@ -4,7 +4,7 @@ K6_VERSION=0.42.0
 
 # service
 SERVICE_NAME=artifact-backend
-SERVICE_PORT=8085
+SERVICE_PORT=8082
 
 # container build
 DOCKER_BUILDKIT=1

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -5,6 +5,10 @@ ARG SERVICE_NAME
 
 WORKDIR /${SERVICE_NAME}
 
+# -- DinD
+
+COPY --from=docker:dind-rootless --chown=nobody:nogroup /usr/local/bin/docker /usr/local/bin
+
 # -- install 3rd-party
 
 ARG TARGETOS TARGETARCH K6_VERSION

--- a/Makefile
+++ b/Makefile
@@ -16,12 +16,10 @@ dev:							## Run dev container
 		echo "Run dev container ${SERVICE_NAME}. To stop it, run \"make stop\"."
 	@docker run -d --rm \
 		-v $(PWD):/${SERVICE_NAME} \
-		-p ${PUBLIC_SERVICE_PORT}:${PUBLIC_SERVICE_PORT} \
-		-p ${PRIVATE_SERVICE_PORT}:${PRIVATE_SERVICE_PORT} \
 		-p ${SERVICE_PORT}:${SERVICE_PORT} \
 		--network instill-network \
 		--name ${SERVICE_NAME} \
-		instill/${SERVICE_NAME}:dev >/dev/null 2>&1
+		instill/${SERVICE_NAME}:dev
 
 .PHONY: logs
 logs:					## Tail service container logs with -n 10


### PR DESCRIPTION
Because

- The `mgmt-backend` Dockerfiles had been copied and used as base but:
  - the `pipeline-backend` and `model-backend` versions are more recent
  - `mgmt-backend` overrides the code while the other two don't, so they fit better as a base

This commit

- Reworks Dockerfiles with `pipeline-backend` as a model
