### PR TITLE
feat: use camelCase for HTTP body

### DIFF
--- a/cmd/main/main.go
+++ b/cmd/main/main.go
@@ -200,7 +200,6 @@ func main() {
 		runtime.WithIncomingHeaderMatcher(middleware.CustomMatcher),
 		runtime.WithMarshalerOption(runtime.MIMEWildcard, &runtime.JSONPb{
 			MarshalOptions: protojson.MarshalOptions{
-				UseProtoNames:   true,
 				EmitUnpopulated: true,
 				UseEnumNumbers:  false,
 			},


### PR DESCRIPTION
Because

- Currently, our API HTTP request and response bodies are a mix of camelCase and snake_case, which is not consistent.

This commit

- Uses camelCase for HTTP bodies.