### PR TITLE
chore(kb): add error check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -122,3 +122,4 @@ test_.pdf
 test_.md
 test_pdf_base64.txt
 .DS_Store
+cmd/main/__debug_bin*

--- a/pkg/handler/knowledgebasefiles.go
+++ b/pkg/handler/knowledgebasefiles.go
@@ -81,13 +81,17 @@ func (ph *PublicHandler) UploadKnowledgeBaseFile(ctx context.Context, req *artif
 		}
 		res, err = ph.service.Repository.CreateKnowledgeBaseFile(ctx, kbFile, func(FileUID string) error {
 			// upload file to minio
-			err = ph.service.MinIO.UploadBase64File(ctx, destination, req.File.Content, fileTypeConvertToMime(req.File.Type))
+			err := ph.service.MinIO.UploadBase64File(ctx, destination, req.File.Content, fileTypeConvertToMime(req.File.Type))
 			if err != nil {
 				return err
 			}
 
 			return nil
 		})
+		if err != nil {
+			log.Error("failed to create knowledge base file", zap.Error(err))
+			return nil, err
+		}
 	}
 
 	return &artifactpb.UploadKnowledgeBaseFileResponse{

--- a/pkg/middleware/interceptor.go
+++ b/pkg/middleware/interceptor.go
@@ -3,6 +3,7 @@ package middleware
 import (
 	"context"
 	"errors"
+	"runtime/debug"
 
 	"github.com/jackc/pgconn"
 	"golang.org/x/crypto/bcrypt"
@@ -24,6 +25,7 @@ import (
 // RecoveryInterceptorOpt - panic handler
 func RecoveryInterceptorOpt() grpc_recovery.Option {
 	return grpc_recovery.WithRecoveryHandler(func(p interface{}) (err error) {
+		debug.PrintStack()
 		return status.Errorf(codes.Unknown, "panic triggered: %v", p)
 	})
 }


### PR DESCRIPTION
Because

1. no enough message when panic
2. existing file err does not be caught cause nil pointer

This commit
1. use debug print
2. catch the dupliacte file error