### PR TITLE
fix(kb): fix db migration error

### DIFF
--- a/pkg/db/migration/000005_add_creator_column_to_knowledge_base_tables.up.sql
+++ b/pkg/db/migration/000005_add_creator_column_to_knowledge_base_tables.up.sql
@@ -1,9 +1,6 @@
 BEGIN;
 -- Add the new column to the knowledge_base table
-ALTER TABLE knowledge_base
-ADD COLUMN creator_uid UUID NOT NULL;
-
+ALTER TABLE knowledge_base ADD COLUMN creator_uid UUID;
 -- Add comment for the new column
 COMMENT ON COLUMN knowledge_base.creator_uid IS 'UUID of the creator of the knowledge base';
-
 COMMIT;


### PR DESCRIPTION
Because

there are some old data already, it cause new colum cannot be not null without default

This commit

remove not null
