### PR TITLE
fix(kb): empty similar chunks

### DIFF
--- a/pkg/milvus/milvus.go
+++ b/pkg/milvus/milvus.go
@@ -366,6 +366,9 @@ func (m *MilvusClient) SearchSimilarEmbeddings(ctx context.Context, collectionNa
 	// Extract the embeddings from the search results
 	var embeddings [][]SimilarEmbedding
 	for _, result := range results {
+		if result.ResultCount == 0 {
+			continue
+		}
 		sourceTables, err := getStringData(result.Fields.GetColumn(KbCollectionFiledSourceTable))
 		if err != nil {
 			log.Error("error with source_table column", zap.Error(err))


### PR DESCRIPTION
Because

when there is no similar chunks in milvus. the zero chunks array  incures error. 

This commit

return empty chunk array instead of error
