### PR TITLE
feat(catalog): check the user tier for catalog limit

### DIFF
--- a/pkg/handler/knowledgebase.go
+++ b/pkg/handler/knowledgebase.go
@@ -63,8 +63,15 @@ func (ph *PublicHandler) CreateCatalog(ctx context.Context, req *artifactpb.Crea
 		log.Error("failed to get catalog count", zap.Error(err))
 		return nil, fmt.Errorf(ErrorCreateKnowledgeBaseMsg, err)
 	}
-	if kbCount >= KnowledgeBaseMaxCount {
-		err := fmt.Errorf("user has reached the 3 maximum number of catalogs: %v. ", kbCount)
+	tier, err := ph.service.GetNamespaceTier(ctx, ns)
+	if err != nil {
+		log.Error("failed to get namespace tier", zap.Error(err))
+		return nil, fmt.Errorf(ErrorCreateKnowledgeBaseMsg, err)
+	}
+	if kbCount >= int64(tier.GetPrivateCatalogLimit()) {
+		err := fmt.Errorf(
+			"user has reached the %v maximum number of catalogs. current tier:%v ",
+			tier.GetPrivateCatalogLimit(), tier)
 		return nil, err
 	}
 

--- a/pkg/service/mgmt.go
+++ b/pkg/service/mgmt.go
@@ -1,0 +1,144 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"math"
+
+	"github.com/gofrs/uuid"
+
+	"github.com/instill-ai/artifact-backend/pkg/logger"
+	"github.com/instill-ai/artifact-backend/pkg/resource"
+	mgmtPB "github.com/instill-ai/protogen-go/core/mgmt/v1beta"
+	"go.uber.org/zap"
+)
+
+func (s *Service) GetNamespaceByNsID(ctx context.Context, nsID string) (*resource.Namespace, error) {
+	log, _ := logger.GetZapLogger(ctx)
+	nsRes, err := s.MgmtPrv.CheckNamespaceAdmin(ctx, &mgmtPB.CheckNamespaceAdminRequest{
+		Id: nsID,
+	},
+	)
+	if err != nil {
+		log.Error("failed to check namespace", zap.Error(err))
+		return nil, fmt.Errorf("failed to check namespace: %w", err)
+	}
+	ownerUUID := nsRes.GetUid()
+	ownerUUIDParsed := uuid.FromStringOrNil(ownerUUID)
+
+	var nsType resource.NamespaceType
+	if nsRes.GetType().String() == mgmtPB.CheckNamespaceAdminResponse_NAMESPACE_ORGANIZATION.String() {
+		nsType = resource.Organization
+	} else if nsRes.GetType().String() == mgmtPB.CheckNamespaceAdminResponse_NAMESPACE_USER.String() {
+		nsType = resource.User
+	} else {
+		err := fmt.Errorf("unknown namespace type: %v", nsRes.GetType().String())
+		return nil, fmt.Errorf("failed to check namespace: %w", err)
+	}
+	ns := resource.Namespace{
+		NsUID:  ownerUUIDParsed,
+		NsType: nsType,
+		NsID:   nsID,
+	}
+	return &ns, nil
+}
+
+// GetNamespaceTierByNsID returns the tier of the namespace given the namespace ID
+func (s *Service) GetNamespaceTierByNsID(ctx context.Context, nsID string) (Tier, error) {
+	ns, err := s.GetNamespaceByNsID(ctx, nsID)
+	if err != nil {
+		return "", fmt.Errorf("failed to get namespace: %w", err)
+	}
+	return s.GetNamespaceTier(ctx, ns)
+}
+
+func (s *Service) GetNamespaceTier(ctx context.Context, ns *resource.Namespace) (Tier, error) {
+	switch ns.NsType {
+	case resource.User:
+		sub, err := s.MgmtPrv.GetUserSubscriptionAdmin(ctx, &mgmtPB.GetUserSubscriptionAdminRequest{
+			UserId: ns.NsID,
+		})
+		if err != nil {
+			return "", fmt.Errorf("failed to get user subscription: %w", err)
+		}
+		if sub.GetSubscription().Plan == mgmtPB.UserSubscription_PLAN_FREE {
+			return TierFree, nil
+		} else if sub.GetSubscription().Plan == mgmtPB.UserSubscription_PLAN_PRO {
+			return TierPro, nil
+		}
+		return "", fmt.Errorf("unknown user subscription plan: %v", sub.GetSubscription().Plan)
+	case resource.Organization:
+		sub, err := s.MgmtPrv.GetOrganizationSubscriptionAdmin(ctx, &mgmtPB.GetOrganizationSubscriptionAdminRequest{
+			OrganizationId: ns.NsID,
+		})
+		if err != nil {
+			return "", fmt.Errorf("failed to get organization subscription: %w", err)
+		}
+		if sub.GetSubscription().Plan == mgmtPB.OrganizationSubscription_PLAN_FREE {
+			return TierFree, nil
+		} else if sub.GetSubscription().Plan == mgmtPB.OrganizationSubscription_PLAN_TEAM {
+			return TierTeam, nil
+		} else if sub.GetSubscription().Plan == mgmtPB.OrganizationSubscription_PLAN_ENTERPRISE {
+			return TierEntriprise, nil
+		}
+		return "", fmt.Errorf("unknown organization subscription plan: %v", sub.GetSubscription().Plan)
+	default:
+		return "", fmt.Errorf("unknown namespace type: %v", ns.NsType)
+	}
+}
+
+type Tier string
+
+const (
+	TierFree       Tier = "free"
+	TierPro        Tier = "pro"
+	TierTeam       Tier = "team"
+	TierEntriprise Tier = "enterprise"
+)
+
+func (t Tier) String() string {
+	return string(t)
+}
+
+func (t Tier) GetPrivateCatalogLimit() int {
+	switch t {
+	case TierFree:
+		return 10
+	case TierPro:
+		return 50
+	case TierTeam:
+		// unlimited
+		return math.MaxInt
+	case TierEntriprise:
+		// unlimited
+		return math.MaxInt
+	}
+	return 0
+}
+
+const mb = 1024 * 1024
+const gb = 1024 * 1024 * 1024
+
+func (t Tier) GetFileStorageTotalQuota() int {
+	switch t {
+	case TierFree:
+		// 50MB
+		return 50 * mb
+	case TierPro:
+		// 500MB
+		return 500 * mb
+	case TierTeam:
+		// 2GB
+		return 2 * gb
+	case TierEntriprise:
+		// unlimited
+		return math.MaxInt
+	}
+	return 0
+}
+
+// GetMaxUploadFileSize returns the maximum file size allowed for the given tier
+// all tier has the same max file size. 150mb
+func (t Tier) GetMaxUploadFileSize() int {
+	return 150 * mb
+}

--- a/pkg/service/mgmt.go
+++ b/pkg/service/mgmt.go
@@ -6,6 +6,8 @@ import (
 	"math"
 
 	"github.com/gofrs/uuid"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/instill-ai/artifact-backend/pkg/logger"
 	"github.com/instill-ai/artifact-backend/pkg/resource"
@@ -43,6 +45,7 @@ func (s *Service) GetNamespaceByNsID(ctx context.Context, nsID string) (*resourc
 	return &ns, nil
 }
 
+// TODO: GetNamespaceTierByNsID: in the future, this logic should be removed in CE. Because CE does not have subscription
 // GetNamespaceTierByNsID returns the tier of the namespace given the namespace ID
 func (s *Service) GetNamespaceTierByNsID(ctx context.Context, nsID string) (Tier, error) {
 	ns, err := s.GetNamespaceByNsID(ctx, nsID)
@@ -52,14 +55,26 @@ func (s *Service) GetNamespaceTierByNsID(ctx context.Context, nsID string) (Tier
 	return s.GetNamespaceTier(ctx, ns)
 }
 
+// TODO: GetNamespaceTier: in the future, this logic should be removed in CE. Because CE does not have subscription
 func (s *Service) GetNamespaceTier(ctx context.Context, ns *resource.Namespace) (Tier, error) {
+	log, _ := logger.GetZapLogger(ctx)
 	switch ns.NsType {
 	case resource.User:
 		sub, err := s.MgmtPrv.GetUserSubscriptionAdmin(ctx, &mgmtPB.GetUserSubscriptionAdminRequest{
 			UserId: ns.NsID,
 		})
 		if err != nil {
-			return "", fmt.Errorf("failed to get user subscription: %w", err)
+			// because CE does not have subscription, mgmt service will return Unimplemented error
+			statusError, ok := status.FromError(err)
+			if ok && statusError.Code() == codes.Unimplemented {
+				// Handle the case where the method is not implemented on the server
+				log.Warn("GetUserSubscriptionAdmin is not implemented. Assuming enterprise tier")
+				return TierEntriprise, nil
+			} else {
+				// Handle other errors
+				return "", fmt.Errorf("failed to get user subscription: %w", err)
+
+			}
 		}
 		if sub.GetSubscription().Plan == mgmtPB.UserSubscription_PLAN_FREE {
 			return TierFree, nil
@@ -72,7 +87,17 @@ func (s *Service) GetNamespaceTier(ctx context.Context, ns *resource.Namespace) 
 			OrganizationId: ns.NsID,
 		})
 		if err != nil {
-			return "", fmt.Errorf("failed to get organization subscription: %w", err)
+			// because CE does not have subscription, mgmt service will return Unimplemented error
+			statusError, ok := status.FromError(err)
+			if ok && statusError.Code() == codes.Unimplemented {
+				// handle the case where the method is not implemented on the server
+				log.Warn("GetUserSubscriptionAdmin is not implemented. Assuming enterprise tier")
+				return TierEntriprise, nil
+			} else {
+				// handle other errors
+				return "", fmt.Errorf("failed to get organization subscription: %w", err)
+
+			}
 		}
 		if sub.GetSubscription().Plan == mgmtPB.OrganizationSubscription_PLAN_FREE {
 			return TierFree, nil
@@ -112,6 +137,7 @@ func (t Tier) GetPrivateCatalogLimit() int {
 	case TierEntriprise:
 		// unlimited
 		return math.MaxInt
+
 	}
 	return 0
 }
@@ -119,22 +145,22 @@ func (t Tier) GetPrivateCatalogLimit() int {
 const mb = 1024 * 1024
 const gb = 1024 * 1024 * 1024
 
-func (t Tier) GetFileStorageTotalQuota() int {
+func (t Tier) GetFileStorageTotalQuota() (int, string) {
 	switch t {
 	case TierFree:
 		// 50MB
-		return 50 * mb
+		return 50 * mb, "50MB"
 	case TierPro:
 		// 500MB
-		return 500 * mb
+		return 500 * mb, "500MB"
 	case TierTeam:
 		// 2GB
-		return 2 * gb
+		return 2 * gb, "2GB"
 	case TierEntriprise:
 		// unlimited
-		return math.MaxInt
+		return math.MaxInt, "unlimited"
 	}
-	return 0
+	return 0, "0"
 }
 
 // GetMaxUploadFileSize returns the maximum file size allowed for the given tier

--- a/pkg/service/utils.go
+++ b/pkg/service/utils.go
@@ -2,14 +2,10 @@ package service
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/gofrs/uuid"
 	"github.com/instill-ai/artifact-backend/pkg/constant"
-	"github.com/instill-ai/artifact-backend/pkg/logger"
 	"github.com/instill-ai/artifact-backend/pkg/resource"
-	mgmtPB "github.com/instill-ai/protogen-go/core/mgmt/v1beta"
-	"go.uber.org/zap"
 )
 
 func (s *Service) CheckNamespacePermission(ctx context.Context, ns *resource.Namespace) error {
@@ -26,34 +22,4 @@ func (s *Service) CheckNamespacePermission(ctx context.Context, ns *resource.Nam
 		return ErrNoPermission
 	}
 	return nil
-}
-
-func (s *Service) GetNamespaceByNsID(ctx context.Context, nsID string) (*resource.Namespace, error) {
-	log, _ := logger.GetZapLogger(ctx)
-	nsRes, err := s.MgmtPrv.CheckNamespaceAdmin(ctx, &mgmtPB.CheckNamespaceAdminRequest{
-		Id: nsID,
-	},
-	)
-	if err != nil {
-		log.Error("failed to check namespace", zap.Error(err))
-		return nil, fmt.Errorf("failed to check namespace: %w", err)
-	}
-	ownerUUID := nsRes.GetUid()
-	ownerUUIDParsed := uuid.FromStringOrNil(ownerUUID)
-
-	var nsType string
-	if nsRes.GetType().String() == mgmtPB.CheckNamespaceAdminResponse_NAMESPACE_ORGANIZATION.String() {
-		nsType = "organizations"
-	} else if nsRes.GetType().String() == mgmtPB.CheckNamespaceAdminResponse_NAMESPACE_USER.String() {
-		nsType = "users"
-	} else {
-		err := fmt.Errorf("unknown namespace type: %v", nsRes.GetType().String())
-		return nil, fmt.Errorf("failed to check namespace: %w", err)
-	}
-	ns := resource.Namespace{
-		NsUID:  ownerUUIDParsed,
-		NsType: resource.NamespaceType(nsType),
-		NsID:   nsID,
-	}
-	return &ns, nil
 }


### PR DESCRIPTION
Because

when creating catalog-related, we have limit for different tier


This commit

add check tier logic in catalog max number and total fie storage.

NOTE: in the future, we should remove the tier-related code in CE.
