### PR TITLE
refactor: wrap goroutines into goRecover

### DIFF
--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"fmt"
 	"strings"
 )
 
@@ -14,4 +15,14 @@ func IsAuditEvent(eventName string) bool {
 	return strings.HasPrefix(eventName, CreateEvent) ||
 		strings.HasPrefix(eventName, UpdateEvent) ||
 		strings.HasPrefix(eventName, DeleteEvent)
+}
+
+// GoRecover take a function as input, if the function panics, the panic will be recovered and the error will be returned
+func GoRecover(f func(), name string) {
+	defer func() {
+		if r := recover(); r != nil {
+			fmt.Println("panic occurred at: ", name, "panic: \n", r)
+		}
+	}()
+	f()
 }


### PR DESCRIPTION
Because

a goroutine's panic can cause the main process to crash.

This commit

wraps the goroutine in a goRecover function, which adds defer recover.
