### PR TITLE
fix(artifact): fix ctx issue

### DIFF
--- a/pkg/handler/knowledgebasefiles.go
+++ b/pkg/handler/knowledgebasefiles.go
@@ -353,6 +353,8 @@ func (ph *PublicHandler) DeleteCatalogFile(
 	// TODO: need to use clean worker in the future
 	go utils.GoRecover(
 		func() {
+			// to prevent parent context from being cancelled, create a new context
+			ctx := context.TODO()
 			//  delete the file from minio
 			objectPaths := []string{}
 			//  kb file in minio


### PR DESCRIPTION
Because

using http ctx will make subsequent goroutine cancled when http response. 

This commit

use new ctx.
