### PR TITLE
fix(artifact): fix retry file process

### DIFF
--- a/pkg/repository/embedding.go
+++ b/pkg/repository/embedding.go
@@ -127,6 +127,10 @@ func (r *Repository) UpsertEmbeddings(
 	logger, _ := logger.GetZapLogger(ctx)
 	// Start a transaction
 	err := r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		if len(embeddings) == 0 {
+			logger.Warn("no embeddings to upsert")
+			return nil
+		}
 		// Upsert the embeddings
 		if err := tx.Clauses(clause.OnConflict{
 			Columns:   []clause.Column{{Name: EmbeddingColumn.SourceTable}, {Name: EmbeddingColumn.SourceUID}}, // Unique column that triggers the upsert

--- a/pkg/service/pipeline.go
+++ b/pkg/service/pipeline.go
@@ -154,7 +154,14 @@ func (s *Service) SplitMarkdownPipe(ctx context.Context, caller uuid.UUID, reque
 	if err != nil {
 		return nil, err
 	}
-	return result, nil
+	// remove the empty chunk
+	var filteredResult []Chunk
+	for _, chunk := range result {
+		if chunk.Text != "" {
+			filteredResult = append(filteredResult, chunk)
+		}
+	}
+	return filteredResult, nil
 }
 
 // GetChunksFromResponse converts the pipeline response into a slice of Chunk.

--- a/pkg/worker/worker.go
+++ b/pkg/worker/worker.go
@@ -310,7 +310,7 @@ func (wp *fileToEmbWorkerPool) checkRegisteredFilesWorker(ctx context.Context, f
 
 // processFile handles the processing of a file through various stages using a state machine.
 func (wp *fileToEmbWorkerPool) processFile(ctx context.Context, file repository.KnowledgeBaseFile) error {
-	// logger, _ := logger.GetZapLogger(ctx)
+	logger, _ := logger.GetZapLogger(ctx)
 	var status artifactpb.FileProcessStatus
 	if statusInt, ok := artifactpb.FileProcessStatus_value[file.ProcessStatus]; !ok {
 		return fmt.Errorf("invalid process status: %v", file.ProcessStatus)
@@ -342,9 +342,9 @@ func (wp *fileToEmbWorkerPool) processFile(ctx context.Context, file repository.
 			status = nextStatus
 			file = *updatedFile
 			convertingTime := int64(time.Since(t0).Seconds())
-			err = wp.svc.Repository.UpdateKbFileExtraMetaData(ctx, file.UID, "", "", "", "", &convertingTime, nil, nil, nil)
+			err = wp.svc.Repository.UpdateKbFileExtraMetaData(ctx, file.UID, "", "", "", "", nil, &convertingTime, nil, nil)
 			if err != nil {
-				fmt.Printf("Error updating file extra metadata: %v\n", err)
+				logger.Error("Error updating file extra metadata", zap.Error(err))
 			}
 
 		case artifactpb.FileProcessStatus_FILE_PROCESS_STATUS_CHUNKING:
@@ -358,7 +358,7 @@ func (wp *fileToEmbWorkerPool) processFile(ctx context.Context, file repository.
 			chunkingTime := int64(time.Since(t0).Seconds())
 			err = wp.svc.Repository.UpdateKbFileExtraMetaData(ctx, file.UID, "", "", "", "", nil, nil, &chunkingTime, nil)
 			if err != nil {
-				fmt.Printf("Error updating file extra metadata: %v\n", err)
+				logger.Error("Error updating file extra metadata", zap.Error(err))
 			}
 
 		case artifactpb.FileProcessStatus_FILE_PROCESS_STATUS_EMBEDDING:
@@ -372,7 +372,7 @@ func (wp *fileToEmbWorkerPool) processFile(ctx context.Context, file repository.
 			embeddingTime := int64(time.Since(t0).Seconds())
 			err = wp.svc.Repository.UpdateKbFileExtraMetaData(ctx, file.UID, "", "", "", "", nil, nil, nil, &embeddingTime)
 			if err != nil {
-				fmt.Printf("Error updating file extra metadata: %v\n", err)
+				logger.Error("Error updating file extra metadata", zap.Error(err))
 			}
 
 		case artifactpb.FileProcessStatus_FILE_PROCESS_STATUS_COMPLETED:

--- a/pkg/worker/worker.go
+++ b/pkg/worker/worker.go
@@ -107,9 +107,9 @@ func (wp *fileToEmbWorkerPool) startDispatcher() {
 				default:
 					select {
 					case wp.channel <- file:
-						fmt.Printf("Dispatcher dispatched file. fileUID: %s\n", file.UID.String())
+						logger.Info("Dispatcher dispatched file.", zap.String("fileUID", file.UID.String()))
 					default:
-						fmt.Println("channel is full, skip dispatching remaining files")
+						logger.Debug("channel is full, skip dispatching remaining files.", zap.String("fileUID", file.UID.String()))
 						break dispatchLoop
 					}
 				}


### PR DESCRIPTION
Because

1. when all processing workers are busy, the dispatch worker continues to send tasks to the queue. These tasks are not held by any workers, so the dispatcher may keep sending the same tasks to the queue. 

2. when chunk text is empty, it still insert into db.

This commit

1. **Add a check at the beginning of each process step** to verify the file’s processing state in the database. If the state does not matches the current process state, discard the file process task.

2. **Set buffer of worker queue to zero** to prevent out of date file status being queued

3. **Skip the chunk's text if it text is empty**