### PR TITLE
feat(artifact): support csv file type upload and some improvements

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.19.1
 	github.com/influxdata/influxdb-client-go/v2 v2.12.3
-	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240826094216-ad773d684498
+	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240920071518-c77545942bf5
 	github.com/instill-ai/usage-client v0.3.0-alpha.0.20240319060111-4a3a39f2fd61
 	github.com/instill-ai/x v0.3.0-alpha.0.20231219052200-6230a89e386c
 	github.com/knadh/koanf v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -342,8 +342,8 @@ github.com/influxdata/influxdb-client-go/v2 v2.12.3 h1:28nRlNMRIV4QbtIUvxhWqaxn0
 github.com/influxdata/influxdb-client-go/v2 v2.12.3/go.mod h1:IrrLUbCjjfkmRuaCiGQg4m2GbkaeJDcuWoxiWdQEbA0=
 github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839 h1:W9WBk7wlPfJLvMCdtV4zPulc4uCPrlywQOmbFOhgQNU=
 github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839/go.mod h1:xaLFMmpvUxqXtVkUJfg9QmT88cDaCJ3ZKgdZ78oO8Qo=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240826094216-ad773d684498 h1:uk5MtLSOAif+Y4rcY+f47LtxX2nPcIXScZaKzzBzKEE=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240826094216-ad773d684498/go.mod h1:2blmpUwiTwxIDnrjIqT6FhR5ewshZZF554wzjXFvKpQ=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240920071518-c77545942bf5 h1:PQK+m0eT7HEMbBJT5PDXj2jyaYrLd2qR5V7D5SNOU8o=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20240920071518-c77545942bf5/go.mod h1:rf0UY7VpEgpaLudYEcjx5rnbuwlBaaLyD4FQmWLtgAY=
 github.com/instill-ai/usage-client v0.3.0-alpha.0.20240319060111-4a3a39f2fd61 h1:smPTvmXDhn/QC7y/TPXyMTqbbRd0gvzmFgWBChwTfhE=
 github.com/instill-ai/usage-client v0.3.0-alpha.0.20240319060111-4a3a39f2fd61/go.mod h1:/TAHs4ybuylk5icuy+MQtHRc4XUnIyXzeNKxX9qDFhw=
 github.com/instill-ai/x v0.3.0-alpha.0.20231219052200-6230a89e386c h1:a2RVkpIV2QcrGnSHAou+t/L+vBsaIfFvk5inVg5Uh4s=

--- a/pkg/handler/knowledgebasefiles.go
+++ b/pkg/handler/knowledgebasefiles.go
@@ -540,6 +540,8 @@ func fileTypeConvertToMime(t artifactpb.FileType) string {
 		return "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
 	case artifactpb.FileType_FILE_TYPE_XLS:
 		return "application/vnd.ms-excel"
+	case artifactpb.FileType_FILE_TYPE_CSV:
+		return "text/csv"
 	default:
 		return "application/octet-stream"
 	}
@@ -567,6 +569,8 @@ func DetermineFileType(fileName string) artifactpb.FileType {
 		return artifactpb.FileType_FILE_TYPE_XLSX
 	} else if strings.HasSuffix(fileName, ".xls") {
 		return artifactpb.FileType_FILE_TYPE_XLS
+	} else if strings.HasSuffix(fileName, ".csv") {
+		return artifactpb.FileType_FILE_TYPE_CSV
 	}
 	return artifactpb.FileType_FILE_TYPE_UNSPECIFIED
 }

--- a/pkg/repository/knowledgebasefile.go
+++ b/pkg/repository/knowledgebasefile.go
@@ -437,7 +437,8 @@ func (r *Repository) GetSourceTableAndUIDByFileUIDs(ctx context.Context, files [
 			artifactpb.FileType_FILE_TYPE_PPT.String(),
 			artifactpb.FileType_FILE_TYPE_PPTX.String(),
 			artifactpb.FileType_FILE_TYPE_XLSX.String(),
-			artifactpb.FileType_FILE_TYPE_XLS.String():
+			artifactpb.FileType_FILE_TYPE_XLS.String(),
+			artifactpb.FileType_FILE_TYPE_CSV.String():
 			convertedFile, err := r.GetConvertedFileByFileUID(ctx, file.UID)
 			if err != nil {
 				if errors.Is(err, gorm.ErrRecordNotFound) {
@@ -542,7 +543,8 @@ func (r *Repository) GetTruthSourceByFileUID(ctx context.Context, fileUID uuid.U
 		artifactpb.FileType_FILE_TYPE_PPT.String(),
 		artifactpb.FileType_FILE_TYPE_PPTX.String(),
 		artifactpb.FileType_FILE_TYPE_XLSX.String(),
-		artifactpb.FileType_FILE_TYPE_XLS.String():
+		artifactpb.FileType_FILE_TYPE_XLS.String(),
+		artifactpb.FileType_FILE_TYPE_CSV.String():
 		convertedFile, err := r.GetConvertedFileByFileUID(ctx, fileUID)
 		if err != nil {
 			if errors.Is(err, gorm.ErrRecordNotFound) {

--- a/pkg/service/chunk.go
+++ b/pkg/service/chunk.go
@@ -33,7 +33,8 @@ func (s *Service) GetChunksByFile(ctx context.Context, file *repository.Knowledg
 		artifactpb.FileType_FILE_TYPE_PPT.String(),
 		artifactpb.FileType_FILE_TYPE_PPTX.String(),
 		artifactpb.FileType_FILE_TYPE_XLSX.String(),
-		artifactpb.FileType_FILE_TYPE_XLS.String():
+		artifactpb.FileType_FILE_TYPE_XLS.String(),
+		artifactpb.FileType_FILE_TYPE_CSV.String():
 		// set the sourceTable and sourceUID
 		convertedFile, err := s.Repository.GetConvertedFileByFileUID(ctx, file.UID)
 		if err != nil {

--- a/pkg/service/pipeline.go
+++ b/pkg/service/pipeline.go
@@ -66,6 +66,8 @@ func (s *Service) ConvertToMDPipe(ctx context.Context, caller uuid.UUID, request
 		prefix = "data:application/vnd.openxmlformats-officedocument.spreadsheetml.sheet;base64,"
 	} else if fileType == artifactPb.FileType_FILE_TYPE_XLS {
 		prefix = "data:application/vnd.ms-excel;base64,"
+	} else if fileType == artifactPb.FileType_FILE_TYPE_CSV {
+		prefix = "data:text/csv;base64,"
 	}
 
 	req := &pipelinePb.TriggerNamespacePipelineReleaseRequest{


### PR DESCRIPTION
Because
1. The document is going to support CSV files, which means we can allow users to upload CSV files into the catalog.
2. When the pipeline call fails, the pipeline info is not saved yet.

This commit
1. Supports the CSV file type 
2. Moves the pipeline info saving process before calling the pipeline.