### PR TITLE
fix(artifact): increase grpc message size

### DIFF
--- a/pkg/constant/constant.go
+++ b/pkg/constant/constant.go
@@ -8,7 +8,7 @@ const (
 	TB
 )
 
-const MaxPayloadSize = 1024 * 1024 * 32
+const MaxPayloadSize = 1024 * 1024 * 256
 
 // Constants for resource owner
 const DefaultUserID string = "admin"


### PR DESCRIPTION
Because

the message too little

This commit

increase larger message size to 256MB