### PR TITLE
feat: add pipeline metadata in error message

### DIFF
--- a/pkg/minio/knowledgebase.go
+++ b/pkg/minio/knowledgebase.go
@@ -59,6 +59,7 @@ type ChunkContentType []byte
 
 // SaveTextChunks saves batch of chunks(text files) to MinIO.
 // rate limiting is implemented to avoid overwhelming the MinIO server.
+// rate limiting is implemented to avoid overwhelming the MinIO server.
 func (m *Minio) SaveTextChunks(ctx context.Context, kbUID string, chunks map[ChunkUIDType]ChunkContentType) error {
 	logger, _ := logger.GetZapLogger(ctx)
 	var wg sync.WaitGroup

--- a/pkg/service/pipeline.go
+++ b/pkg/service/pipeline.go
@@ -359,11 +359,11 @@ func GetVectorsFromResponse(resp *pipelinePb.TriggerNamespacePipelineReleaseResp
 	for _, output := range resp.Outputs {
 		embedResult, ok := output.GetFields()["embed_result"]
 		if !ok {
-			return nil, fmt.Errorf("embed_result not found in the output fields. output: %v", output)
+			return nil, fmt.Errorf("embed_result not found in the output fields. pipeline's output: %v. pipeline's metadata: %v", output, resp.Metadata)
 		}
 		listValue := embedResult.GetListValue()
 		if listValue == nil {
-			return nil, fmt.Errorf("embed_result is not a list. output: %v", output)
+			return nil, fmt.Errorf("embed_result is not a list. pipeline's output: %v. pipeline's metadata: %v", output, resp.Metadata)
 		}
 
 		vector := make([]float32, 0, len(listValue.GetValues()))


### PR DESCRIPTION
Because

artifact need more error message to debug

This commit

add calling pipeline's metadata to error message
