### PR TITLE
feat: add check on text prompt

### DIFF
--- a/pkg/service/retrieval.go
+++ b/pkg/service/retrieval.go
@@ -19,6 +19,10 @@ type SimChunk struct {
 func (s *Service) SimilarityChunksSearch(ctx context.Context, caller uuid.UUID, requester uuid.UUID, ownerUID uuid.UUID, req *artifactPb.SimilarityChunksSearchRequest) ([]SimChunk, error) {
 	log, _ := logger.GetZapLogger(ctx)
 	t := time.Now()
+	// check if text prompt is empty
+	if req.TextPrompt == "" {
+		return nil, fmt.Errorf("text prompt is empty in SimilarityChunksSearch")
+	}
 	textVector, err := s.EmbeddingTextPipe(ctx, caller, requester, []string{req.TextPrompt})
 	if err != nil {
 		log.Error("failed to vectorize text", zap.Error(err))


### PR DESCRIPTION
Because

the embedding pipleine can not allow empty text.

This commit

check the text prompt and throw the better understanding error message