### PR TITLE
feat(blob): add domain in objecturl

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -31,6 +31,7 @@ type AppConfig struct {
 	Minio                 MinioConfig           `koanf:"minio"`
 	Milvus                MilvusConfig          `koanf:"milvus"`
 	FileToEmbeddingWorker FileToEmbeddingWorker `koanf:"filetoembeddingworker"`
+	Blob                  BlobConfig            `koanf:"blob"`
 }
 
 // OpenFGA config
@@ -157,6 +158,10 @@ type MilvusConfig struct {
 
 type FileToEmbeddingWorker struct {
 	NumberOfWorkers int `koanf:"numberofworkers"`
+}
+
+type BlobConfig struct {
+	HostPort string `koanf:"hostport"`
 }
 
 // Init - Assign global config to decoded config struct

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -76,3 +76,5 @@ milvus:
   port: 19530
 filetoembeddingworker:
   numberofworkers: 2
+blob:
+  hostport: http://localhost:8080

--- a/pkg/service/object.go
+++ b/pkg/service/object.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/gofrs/uuid"
 	"github.com/gogo/status"
+	"github.com/instill-ai/artifact-backend/config"
 	"github.com/instill-ai/artifact-backend/pkg/logger"
 	minio_local "github.com/instill-ai/artifact-backend/pkg/minio"
 	"github.com/instill-ai/artifact-backend/pkg/repository"
@@ -228,7 +229,7 @@ func EncodedMinioURLPath(namespaceID string, objectURLUUID uuid.UUID) string {
 	urlPath := path.Join("v1alpha", "namespaces", namespaceID, "blob-urls", objectURLUUID.String())
 
 	// Ensure the path starts with a forward slash
-	return "/" + urlPath
+	return config.Config.Blob.HostPort + "/" + urlPath
 }
 
 // DecodeMinioURLPath decodes the minio URL path into namespaceID and objectName


### PR DESCRIPTION
Because

for easy usage of our blob service, object url needs the domain

This commit

add the domain in url