### PR TITLE
fix(artifact): fix advanced index pipeline

### DIFF
--- a/pkg/service/pipeline.go
+++ b/pkg/service/pipeline.go
@@ -30,7 +30,7 @@ const DocToMDVersion = "v1.1.1"
 
 // Note: this pipeline is for the new indexing pipeline having convert_result or convert_result2
 const ConvertDocToMDPipelineID2 = "indexing-advanced-convert-doc"
-const DocToMDVersion2 = "v1.3.0"
+const DocToMDVersion2 = "v1.3.1"
 
 const ChunkMdPipelineID = "indexing-split-markdown"
 const ChunkMdVersion = "v2.0.0"
@@ -107,6 +107,7 @@ func (s *Service) ConvertToMDPipeForFilesInPersistentCatalog(ctx context.Context
 			{
 				Fields: map[string]*structpb.Value{
 					"document_input": {Kind: &structpb.Value_StringValue{StringValue: prefix + fileBase64}},
+					"vlm_model":      {Kind: &structpb.Value_StringValue{StringValue: "gpt-4o"}},
 				},
 			},
 		},


### PR DESCRIPTION
Because

there is a bug in pipeline

This commit

try to use latest version of pipleine for indexing