### PR TITLE
chore(preset): rename `format` to `type` in preset pipelines

### DIFF
--- a/pkg/service/preset/pipelines/indexing-advanced-convert-doc/v1.3.1/recipe.yaml
+++ b/pkg/service/preset/pipelines/indexing-advanced-convert-doc/v1.3.1/recipe.yaml
@@ -3,11 +3,11 @@ variable:
   document_input:
     title: document-input
     description: Upload a document (PDF/DOCX/DOC/PPTX/PPT)
-    format: file
+    type: file
   vlm_model:
     title: vlm-model
     description: OpenAI VLM to read images e.g., gpt-4o-mini or gpt-4o
-    format: string
+    type: string
 component:
   pages-to-images:
     type: document

--- a/pkg/service/preset/pipelines/indexing-convert-pdf/v1.1.1/recipe.yaml
+++ b/pkg/service/preset/pipelines/indexing-convert-pdf/v1.1.1/recipe.yaml
@@ -9,7 +9,7 @@ variable:
   document_input:
     title: document-input
     description: Upload a document (PDF/DOCX/DOC/PPTX/PPT/HTML)
-    format: file
+    type: file
 output:
   convert_result:
     title: convert-result

--- a/pkg/service/preset/pipelines/indexing-embed/v1.1.0/recipe.yaml
+++ b/pkg/service/preset/pipelines/indexing-embed/v1.1.0/recipe.yaml
@@ -11,7 +11,7 @@ component:
 variable:
   chunk_input:
     title: chunk-input
-    format: string
+    type: string
     instill-ui-multiline: true
 output:
   embed_result:

--- a/pkg/service/preset/pipelines/indexing-split-markdown/v2.0.0/recipe.yaml
+++ b/pkg/service/preset/pipelines/indexing-split-markdown/v2.0.0/recipe.yaml
@@ -16,16 +16,16 @@ variable:
   chunk_overlap:
     title: chunk-overlap
     description: number of tokens that overlap between consecutive chunks
-    format: number
+    type: number
   max_chunk_length:
     title: max-chunk-length
     description: splitting maximum tokens size
-    format: number
+    type: number
     instill-ui-order: 2
   md_input:
     title: md-input
     description: original extracted markdown text (single source of truth)
-    format: string
+    type: string
     instill-ui-order: 1
     instill-ui-multiline: true
 output:

--- a/pkg/service/preset/pipelines/indexing-split-text/v2.0.0/recipe.yaml
+++ b/pkg/service/preset/pipelines/indexing-split-text/v2.0.0/recipe.yaml
@@ -16,15 +16,15 @@ variable:
   chunk_overlap:
     title: chunk-overlap
     description: number of tokens that overlap between consecutive chunks
-    format: number
+    type: number
     instill-ui-order: 2
   max_chunk_length:
     title: max-chunk-length
     description: splitting maximum tokens size
-    format: number
+    type: number
   text_input:
     title: text-input
-    format: string
+    type: string
     instill-ui-order: 1
     instill-ui-multiline: true
 output:

--- a/pkg/service/preset/pipelines/retrieving-qna/v1.2.0/recipe.yaml
+++ b/pkg/service/preset/pipelines/retrieving-qna/v1.2.0/recipe.yaml
@@ -40,12 +40,12 @@ variable:
   retrieved_chunk:
     title: retrieved-chunk
     description: chunks search result, using \n\n to combine all the relevant chunk texts
-    format: string
+    type: string
     instill-ui-multiline: true
   user_question:
     title: user-question
     description: user query (single-turn)
-    format: string
+    type: string
     instill-ui-multiline: true
 output:
   assistant_reply:


### PR DESCRIPTION
This commit

- renames `format` to `type` in preset pipelines
