### PR TITLE
feat(minio): emit MinIO audit logs in service logs

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -25,8 +25,8 @@ RUN go mod download
 COPY . .
 
 RUN chown -R nobody:nogroup /go
-ENV GOCACHE /go/.cache/go-build
-ENV GOENV /go/.config/go/env
+ENV GOCACHE=/go/.cache/go-build
+ENV GOENV=/go/.config/go/env
 
 USER nobody:nogroup
 

--- a/cmd/main/main.go
+++ b/cmd/main/main.go
@@ -156,17 +156,14 @@ func main() {
 
 	publicGrpcS := grpc.NewServer(grpcServerOpts...)
 	reflection.Register(publicGrpcS)
-	artifactpb.RegisterArtifactPublicServiceServer(
-		publicGrpcS,
-		handler.NewPublicHandler(ctx, service),
-	)
+	publicHandler := handler.NewPublicHandler(service, logger)
+	artifactpb.RegisterArtifactPublicServiceServer(publicGrpcS, publicHandler)
 
 	privateGrpcS := grpc.NewServer(grpcServerOpts...)
 	reflection.Register(privateGrpcS)
-	artifactpb.RegisterArtifactPrivateServiceServer(
-		privateGrpcS,
-		handler.NewPrivateHandler(ctx, service),
-	)
+
+	privateHandler := handler.NewPrivateHandler(service, logger)
+	artifactpb.RegisterArtifactPrivateServiceServer(privateGrpcS, privateHandler)
 
 	publicServeMux := runtime.NewServeMux(
 		runtime.WithForwardResponseOption(middleware.HTTPResponseModifier),

--- a/config/config.go
+++ b/config/config.go
@@ -67,6 +67,9 @@ type ServerConfig struct {
 		MaxWorkflowRetry   int32 `koanf:"maxworkflowretry"`
 		MaxActivityRetry   int32 `koanf:"maxactivityretry"`
 	}
+
+	// IngestMinIOLogs enables the MinIO audit log webhook.
+	IngestMinIOLogs bool `koanf:"logminioaudit"`
 }
 
 // DatabaseConfig related to database
@@ -144,10 +147,10 @@ type RegistryConfig struct {
 
 // MinioConfig is the minio configuration.
 type MinioConfig struct {
-	Host                    string `koanf:"host"`
-	Port                    string `koanf:"port"`
-	RootUser                string `koanf:"rootuser"`
-	RootPwd                 string `koanf:"rootpwd"`
+	Host     string `koanf:"host"`
+	Port     string `koanf:"port"`
+	RootUser string `koanf:"rootuser"`
+	RootPwd  string `koanf:"rootpwd"`
 }
 
 // MilvusConfig is the milvus configuration.

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -16,6 +16,7 @@ server:
     maxworkflowtimeout: 3600 # in seconds
     maxworkflowretry: 1
     maxactivityretry: 3
+  logminioaudit: true
 database:
   username: postgres
   password: password

--- a/go.mod
+++ b/go.mod
@@ -104,5 +104,3 @@ require (
 	google.golang.org/genproto/googleapis/api v0.0.0-20240528184218-531527333157 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
-
-// replace github.com/instill-ai/protogen-go => ./protogen-go

--- a/pkg/handler/minio.go
+++ b/pkg/handler/minio.go
@@ -1,0 +1,52 @@
+package handler
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+
+	"go.uber.org/zap"
+)
+
+type minIOAuditLog struct {
+	Time string `json:"time"`
+	API  struct {
+		Name   string `json:"name"`
+		Bucket string `json:"bucket"`
+		Object string `json:"object"`
+		Status string `json:"status"`
+	} `json:"api"`
+	RemoteHost    string `json:"remotehost"`
+	AccessKey     string `json:"accessKey"`
+	UserAgent     string `json:"userAgent"`
+	RequestHeader struct {
+		InstillUserUID string `json:"X-Amz-Meta-Instill-User-Uid,omitempty"`
+	} `json:"requestHeader,omitempty"`
+}
+
+// IngestMinIOAuditLogs receives and logs the MinIO audit logs in order to
+// track which actions are performed and by whom on MinIO.
+// The server's audit log webhook points to this endpoint so, even if is placed
+// under artifact-backend, the logs reflect the actions from any MinIO client.
+// In the future, this might be extracted to a dedicated service or a lambda /
+// cloud run function.
+func (h *PrivateHandler) IngestMinIOAuditLogs(w http.ResponseWriter, r *http.Request, _ map[string]string) {
+	body, err := io.ReadAll(r.Body)
+	defer r.Body.Close()
+	if err != nil {
+		h.log.Error("Failed to read MinIO audit log body", zap.Error(err))
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	var auditLog minIOAuditLog
+	if err := json.Unmarshal(body, &auditLog); err != nil {
+		h.log.Error("Failed to unmarshal MinIO audit log", zap.Error(err))
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	h.log.Info("MinIO audit log", zap.Any("body", auditLog))
+
+	w.WriteHeader(http.StatusOK)
+}

--- a/pkg/handler/public.go
+++ b/pkg/handler/public.go
@@ -7,20 +7,22 @@ import (
 	artifact "github.com/instill-ai/artifact-backend/pkg/service"
 	artifactpb "github.com/instill-ai/protogen-go/artifact/artifact/v1alpha"
 	healthcheckpb "github.com/instill-ai/protogen-go/common/healthcheck/v1beta"
+	"go.uber.org/zap"
 )
 
 // PublicHandler handles public API
 type PublicHandler struct {
 	artifactpb.UnimplementedArtifactPublicServiceServer
-	ctx     context.Context
 	service *artifact.Service
+	log     *zap.Logger
 }
 
 // NewPublicHandler initiates a handler instance
-func NewPublicHandler(ctx context.Context, service *artifact.Service) artifactpb.ArtifactPublicServiceServer {
+func NewPublicHandler(service *artifact.Service, log *zap.Logger) *PublicHandler {
 	return &PublicHandler{
-		ctx:     ctx,
-		service: service}
+		service: service,
+		log:     log,
+	}
 }
 
 // Liveness returns the health of the service.


### PR DESCRIPTION
Because

- To improve user data protection, we need to trace who performed each action on MinIO objects.

This commit

- Exposes a private endpoint to ingest MinIO's audit logs and log the relevant information.
- Related: instill-ai/x/pull/36
