### PR TITLE
feat(minio): add service name and version to MinIO requests

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -36,6 +36,7 @@ jobs:
           push: true
           build-args: |
             SERVICE_NAME=artifact-backend
+            SERVICE_VERSION=${{ github.sha }}
           tags: instill/artifact-backend:latest
           cache-from: type=registry,ref=instill/artifact-backend:buildcache
           cache-to: type=registry,ref=instill/artifact-backend:buildcache,mode=max
@@ -60,6 +61,7 @@ jobs:
           push: true
           build-args: |
             SERVICE_NAME=artifact-backend
+            SERVICE_VERSION=${{steps.set_version.outputs.no_v_tag}}
           tags: instill/artifact-backend:${{steps.set_version.outputs.no_v_tag}}
           cache-from: type=registry,ref=instill/artifact-backend:buildcache
           cache-to: type=registry,ref=instill/artifact-backend:buildcache,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,21 +8,27 @@ RUN --mount=type=cache,target=/go/pkg/mod \
     go mod download
 COPY . .
 
-ARG SERVICE_NAME TARGETOS TARGETARCH
+ARG SERVICE_NAME SERVICE_VERSION TARGETOS TARGETARCH
 
 RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
-    GOOS=$TARGETOS GOARCH=$TARGETARCH CGO_ENABLED=0 go build -o /${SERVICE_NAME} ./cmd/main
+    GOOS=$TARGETOS GOARCH=$TARGETARCH CGO_ENABLED=0 \
+    go build -ldflags "-X main.version=${SERVICE_VERSION} -X main.serviceName=${SERVICE_NAME}" \
+    -o /${SERVICE_NAME} ./cmd/main
 
 # Build the migration tool
 RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
-    GOOS=$TARGETOS GOARCH=$TARGETARCH CGO_ENABLED=0 go build -o /${SERVICE_NAME}-migrate ./cmd/migration
+    GOOS=$TARGETOS GOARCH=$TARGETARCH CGO_ENABLED=0 \
+    go build -ldflags "-X main.version=${SERVICE_VERSION} -X main.serviceName=${SERVICE_NAME}-init" \
+    -o /${SERVICE_NAME}-migrate ./cmd/migration
 
 # Build the init tool
 RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
-    GOOS=$TARGETOS GOARCH=$TARGETARCH CGO_ENABLED=0 go build -o /${SERVICE_NAME}-init ./cmd/init
+    GOOS=$TARGETOS GOARCH=$TARGETARCH CGO_ENABLED=0 \
+    go build -ldflags "-X main.version=${SERVICE_VERSION} -X main.serviceName=${SERVICE_NAME}-init" \
+    -o /${SERVICE_NAME}-init ./cmd/init
 
 
 FROM golang:1.23.4


### PR DESCRIPTION
Because

- We want to trace the origin or MinIO actions.

This commit

- Adds the service name and version to the MinIO request headers.
- For the moment it doesn't add the authenticated user that's triggering the request. This will be achieved more easily by leveraging the `x/minio` client.
