### PR TITLE
chore(minio): always print audit logs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$TARGETPLATFORM golang:1.23.4 AS build
+FROM golang:1.23.4 AS build
 
 WORKDIR /src
 

--- a/cmd/main/main.go
+++ b/cmd/main/main.go
@@ -258,11 +258,8 @@ func main() {
 		logger.Fatal(err.Error())
 	}
 
-	if config.Config.Server.IngestMinIOLogs {
-		err := privateServeMux.HandlePath("POST", "/v1alpha/minio-audit", privateHandler.IngestMinIOAuditLogs)
-		if err != nil {
-			logger.Fatal("Failed to set up MinIO audit endpoint", zap.Error(err))
-		}
+	if err := privateServeMux.HandlePath("POST", "/v1alpha/minio-audit", privateHandler.IngestMinIOAuditLogs); err != nil {
+		logger.Fatal("Failed to set up MinIO audit endpoint", zap.Error(err))
 	}
 
 	privateHTTPServer := &http.Server{

--- a/config/config.go
+++ b/config/config.go
@@ -69,9 +69,6 @@ type ServerConfig struct {
 		MaxWorkflowRetry   int32 `koanf:"maxworkflowretry"`
 		MaxActivityRetry   int32 `koanf:"maxactivityretry"`
 	}
-
-	// IngestMinIOLogs enables the MinIO audit log webhook.
-	IngestMinIOLogs bool `koanf:"logminioaudit"`
 }
 
 // DatabaseConfig related to database

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -16,7 +16,6 @@ server:
     maxworkflowtimeout: 3600 # in seconds
     maxworkflowretry: 1
     maxactivityretry: 3
-  logminioaudit: true
 database:
   username: postgres
   password: password


### PR DESCRIPTION
Because

- We want to always print the MinIO audit logs. If we make this behaviour
  configurable, it'll be after it's released and verified.

This commit

- Remove config variable to toggle MinIO webhook behaviour.
