### PR TITLE
fix(search): support metadata-less embeddings search

### DIFF
--- a/pkg/db/migration/000021_rename_content_and_add_chunk_type.up.sql
+++ b/pkg/db/migration/000021_rename_content_and_add_chunk_type.up.sql
@@ -2,8 +2,8 @@ BEGIN;
 
 -- Add new columns file_type and content_type for text_chunk
 ALTER TABLE text_chunk
-ADD COLUMN file_type VARCHAR(255),
-ADD COLUMN content_type VARCHAR(255);
+ADD COLUMN file_type VARCHAR(255) DEFAULT 'document',
+ADD COLUMN content_type VARCHAR(255) DEFAULT 'chunk';
 
 -- Add a comment for the new column
 COMMENT ON COLUMN text_chunk.file_type IS 'file type';
@@ -11,8 +11,8 @@ COMMENT ON COLUMN text_chunk.content_type IS 'content type';
 
 -- Add new columns file_type and content_type for text_chunk
 ALTER TABLE embedding
-ADD COLUMN file_type VARCHAR(255),
-ADD COLUMN content_type VARCHAR(255);
+ADD COLUMN file_type VARCHAR(255) DEFAULT 'document',
+ADD COLUMN content_type VARCHAR(255) DEFAULT 'chunk';
 
 -- Add a comment for the new column
 COMMENT ON COLUMN embedding.file_type IS 'file type';


### PR DESCRIPTION
Because

- collections does not support adding new fields, and similarity search should support collections without metadata

This commit

- support metadata-less embeddings search
