### PR TITLE
chore(catalog): support optional id

### DIFF
--- a/pkg/handler/knowledgebase.go
+++ b/pkg/handler/knowledgebase.go
@@ -22,6 +22,8 @@ import (
 	artifactpb "github.com/instill-ai/protogen-go/artifact/artifact/v1alpha"
 )
 
+var alphabet = "abcdefghijklmnopqrstuvwxyz"
+
 type ErrorMsg map[int]string
 
 const ErrorCreateKnowledgeBaseMsg = "failed to create catalog: %w"
@@ -500,11 +502,10 @@ func isValidName(name string) bool {
 }
 
 func generateID() string {
-	var alphabet = "abcdefghijklmnopqrstuvwxyz"
-	rand.Seed(time.Now().UnixNano())
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
 	id := make([]byte, 8)
 	for i := range id {
-		id[i] = alphabet[rand.Intn(len(alphabet))]
+		id[i] = alphabet[r.Intn(len(alphabet))]
 	}
 
 	return string(id)

--- a/pkg/handler/knowledgebase.go
+++ b/pkg/handler/knowledgebase.go
@@ -3,8 +3,10 @@ package handler
 import (
 	"context"
 	"fmt"
+	"math/rand"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/gofrs/uuid"
 	"go.uber.org/zap"
@@ -79,8 +81,7 @@ func (ph *PublicHandler) CreateCatalog(ctx context.Context, req *artifactpb.Crea
 
 	// check name if it is empty
 	if req.Name == "" {
-		err := fmt.Errorf("name is required. err: %w", ErrCheckRequiredFields)
-		return nil, err
+		req.Name = generateID()
 	}
 	nameOk := isValidName(req.Name)
 	if !nameOk {
@@ -496,4 +497,15 @@ func isValidName(name string) bool {
 	re := regexp.MustCompile(pattern)
 	// Match the name against the regular expression
 	return re.MatchString(name)
+}
+
+func generateID() string {
+	var alphabet = "abcdefghijklmnopqrstuvwxyz"
+	rand.Seed(time.Now().UnixNano())
+	id := make([]byte, 8)
+	for i := range id {
+		id[i] = alphabet[rand.Intn(len(alphabet))]
+	}
+
+	return string(id)
 }


### PR DESCRIPTION
Because

- FE has scenario that requires random catalog id

This commit

- support optional id
