### PR TITLE
refactor(catalog): update limit for catalog and file

### DIFF
--- a/pkg/handler/knowledgebase.go
+++ b/pkg/handler/knowledgebase.go
@@ -61,25 +61,27 @@ func (ph *PublicHandler) CreateCatalog(ctx context.Context, req *artifactpb.Crea
 			zap.String("auth_uid", authUID))
 		return nil, fmt.Errorf(ErrorCreateKnowledgeBaseMsg, err)
 	}
+
+	// NO CATALOG LIMIT
 	// check if user has reached the maximum number of catalogs
 	// note: the simple implementation have race condition to bypass the check,
 	// but it is okay for now
-	kbCount, err := ph.service.Repository.GetKnowledgeBaseCountByOwner(ctx, ns.NsUID.String(), artifactpb.CatalogType_CATALOG_TYPE_PERSISTENT)
-	if err != nil {
-		log.Error("failed to get catalog count", zap.Error(err))
-		return nil, fmt.Errorf(ErrorCreateKnowledgeBaseMsg, err)
-	}
-	tier, err := ph.service.GetNamespaceTier(ctx, ns)
-	if err != nil {
-		log.Error("failed to get namespace tier", zap.Error(err))
-		return nil, fmt.Errorf(ErrorCreateKnowledgeBaseMsg, err)
-	}
-	if kbCount >= int64(tier.GetPrivateCatalogLimit()) {
-		err := fmt.Errorf(
-			"user has reached the %v maximum number of catalogs. current tier:%v ",
-			tier.GetPrivateCatalogLimit(), tier)
-		return nil, err
-	}
+	// kbCount, err := ph.service.Repository.GetKnowledgeBaseCountByOwner(ctx, ns.NsUID.String(), artifactpb.CatalogType_CATALOG_TYPE_PERSISTENT)
+	// if err != nil {
+	// 	log.Error("failed to get catalog count", zap.Error(err))
+	// 	return nil, fmt.Errorf(ErrorCreateKnowledgeBaseMsg, err)
+	// }
+	// tier, err := ph.service.GetNamespaceTier(ctx, ns)
+	// if err != nil {
+	// 	log.Error("failed to get namespace tier", zap.Error(err))
+	// 	return nil, fmt.Errorf(ErrorCreateKnowledgeBaseMsg, err)
+	// }
+	// if kbCount >= int64(tier.GetPrivateCatalogLimit()) {
+	// 	err := fmt.Errorf(
+	// 		"user has reached the %v maximum number of catalogs. current tier:%v ",
+	// 		tier.GetPrivateCatalogLimit(), tier)
+	// 	return nil, err
+	// }
 
 	// check name if it is empty
 	if req.Name == "" {

--- a/pkg/handler/knowledgebasefiles.go
+++ b/pkg/handler/knowledgebasefiles.go
@@ -112,13 +112,14 @@ func (ph *PublicHandler) UploadCatalogFile(ctx context.Context, req *artifactpb.
 				customerror.ErrInvalidArgument)
 		}
 
+		// NO LIMIT ON TOTAL STORAGE USE
 		// check if total usage in namespace
-		quota, humanReadable := tier.GetFileStorageTotalQuota()
-		if totalUsageInNamespace+fileSize > int64(quota) {
-			return nil, fmt.Errorf(
-				"file storage total quota exceeded. max: %v. tier:%v, err: %w",
-				humanReadable, tier.String(), customerror.ErrInvalidArgument)
-		}
+		// quota, humanReadable := tier.GetFileStorageTotalQuota()
+		// if totalUsageInNamespace+fileSize > int64(quota) {
+		// 	return nil, fmt.Errorf(
+		// 		"file storage total quota exceeded. max: %v. tier:%v, err: %w",
+		// 		humanReadable, tier.String(), customerror.ErrInvalidArgument)
+		// }
 
 		destination := ph.service.MinIO.GetUploadedFilePathInKnowledgeBase(kb.UID.String(), req.File.Name)
 		kbFile := repository.KnowledgeBaseFile{
@@ -176,13 +177,13 @@ func (ph *PublicHandler) UploadCatalogFile(ctx context.Context, req *artifactpb.
 				customerror.ErrInvalidArgument)
 		}
 
-		// check if total usage in namespace
-		quota, humanReadable := tier.GetFileStorageTotalQuota()
-		if totalUsageInNamespace+object.Size > int64(quota) {
-			return nil, fmt.Errorf(
-				"file storage total quota exceeded. max: %v. tier:%v, err: %w",
-				humanReadable, tier.String(), customerror.ErrInvalidArgument)
-		}
+		// NO LIMIT ON TOTAL STORAGE USE
+		// quota, humanReadable := tier.GetFileStorageTotalQuota()
+		// if totalUsageInNamespace+object.Size > int64(quota) {
+		// 	return nil, fmt.Errorf(
+		// 		"file storage total quota exceeded. max: %v. tier:%v, err: %w",
+		// 		humanReadable, tier.String(), customerror.ErrInvalidArgument)
+		// }
 
 		req.File.Type = DetermineFileType(object.Name)
 

--- a/pkg/service/mgmt.go
+++ b/pkg/service/mgmt.go
@@ -163,7 +163,7 @@ func (t Tier) GetFileStorageTotalQuota() (int, string) {
 }
 
 // GetMaxUploadFileSize returns the maximum file size allowed for the given tier
-// all tier has the same max file size. 150mb
+// all tier has the same max file size. 512mb
 func (t Tier) GetMaxUploadFileSize() int {
-	return 150 * mb
+	return 512 * mb
 }


### PR DESCRIPTION
Because

- new storage policy

This commit

- update limit for catalog and file
