### PR TITLE
fix(chunk): prevent the full table query

### DIFF
--- a/pkg/repository/chunk.go
+++ b/pkg/repository/chunk.go
@@ -233,6 +233,9 @@ func (r *Repository) GetFilesTotalTokens(ctx context.Context, sources map[FileUI
 	SourceUID   SourceUID
 }) (map[FileUID]int, error) {
 	result := make(map[FileUID]int)
+	if len(sources) == 0 {
+		return result, nil
+	}
 
 	// Prepare the conditions for the query
 	var conditions []string
@@ -282,6 +285,9 @@ func (r *Repository) GetTotalChunksBySources(ctx context.Context, sources map[Fi
 	SourceUID   SourceUID
 }) (map[FileUID]int, error) {
 	result := make(map[FileUID]int)
+	if len(sources) == 0 {
+		return result, nil
+	}
 
 	// Prepare the conditions for the query
 	var conditions []string


### PR DESCRIPTION
Because

- An incorrect TextChunk causes the DB to perform a redundant full table scan. Since the query returns results that are never used, we can skip it entirely if it’s not needed.

This commit

- Prevents the unnecessary full table query.