### PR TITLE
chore(kbfile): use Docling for file conversion'

### DIFF
--- a/pkg/service/pipeline.go
+++ b/pkg/service/pipeline.go
@@ -132,6 +132,13 @@ func (s *Service) ConvertToMDPipe(ctx context.Context, fileUID uuid.UUID, fileBa
 		return "", fmt.Errorf("failed to trigger %s pipeline: %w", pipelineID, err)
 	}
 
+	convertingModelMetadata := NamespaceID + "/" + ConvertDocToMDModelID + "@" + ConvertDocToMDModelVersion
+	err = s.Repository.UpdateKbFileExtraMetaData(ctx, fileUID, "", convertingModelMetadata, "", "", "", nil, nil, nil, nil, nil)
+	if err != nil {
+		logger.Error("Failed to save converting pipeline metadata.", zap.String("File uid:", fileUID.String()))
+		return "", fmt.Errorf("failed to save converting model metadata: %w", err)
+	}
+
 	result, err := getConvertResult(resp)
 	if err != nil {
 		logger.Error("failed to get convert result", zap.Error(err))

--- a/pkg/worker/persistentcatalogworker.go
+++ b/pkg/worker/persistentcatalogworker.go
@@ -412,22 +412,17 @@ func (wp *persistentCatalogFileToEmbWorkerPool) processConvertingFile(ctx contex
 	// convert the pdf file to md
 	var convertedMD string
 	switch file.Type {
-	// The model-backend conversion method has been disabled temporarily.
-	// This will be a feature in Instill Agent and, on Instill Core, users
-	// will be able to select the conversion pipeline.
-	/*
-		case artifactpb.FileType_FILE_TYPE_PDF.String(),
-			artifactpb.FileType_FILE_TYPE_DOC.String(),
-			artifactpb.FileType_FILE_TYPE_DOCX.String():
-			convertedMD, err = wp.svc.ConvertToMDModel(ctx, file.UID, base64Data, artifactpb.FileType(artifactpb.FileType_value[file.Type]))
-			if err != nil {
-				logger.Error("Failed to convert pdf to md using docling model, fallback to pipeline.")
-				if convertedMD, err = wp.svc.ConvertToMDPipe(ctx, file.UID, base64Data, artifactpb.FileType(artifactpb.FileType_value[file.Type])); err != nil {
-					logger.Error("Failed to convert pdf to md using pdf-to-md pipeline.", zap.String("File path", fileInMinIOPath))
-					return nil, artifactpb.FileProcessStatus_FILE_PROCESS_STATUS_UNSPECIFIED, err
-				}
+	case artifactpb.FileType_FILE_TYPE_PDF.String(),
+		artifactpb.FileType_FILE_TYPE_DOC.String(),
+		artifactpb.FileType_FILE_TYPE_DOCX.String():
+		convertedMD, err = wp.svc.ConvertToMDModel(ctx, file.UID, base64Data, artifactpb.FileType(artifactpb.FileType_value[file.Type]))
+		if err != nil {
+			logger.Error("Failed to convert pdf to md using docling model, fallback to pipeline.")
+			if convertedMD, err = wp.svc.ConvertToMDPipe(ctx, file.UID, base64Data, artifactpb.FileType(artifactpb.FileType_value[file.Type])); err != nil {
+				logger.Error("Failed to convert pdf to md using pdf-to-md pipeline.", zap.String("File path", fileInMinIOPath))
+				return nil, artifactpb.FileProcessStatus_FILE_PROCESS_STATUS_UNSPECIFIED, err
 			}
-	*/
+		}
 	default:
 		if convertedMD, err = wp.svc.ConvertToMDPipe(ctx, file.UID, base64Data, artifactpb.FileType(artifactpb.FileType_value[file.Type])); err != nil {
 			logger.Error("Failed to convert pdf to md using pdf-to-md pipeline.", zap.String("File path", fileInMinIOPath))


### PR DESCRIPTION
Because

- 304325c is a bug in production that we need to hotfix.

This commit

- Reverts b411242e89f1963d7c66f26c302ad3d4af24d0f5 to isolate the fix in a
  release. The changes will be added back after a release version has been
  created so they can be properly tested in staging.
