### PR TITLE
chore(subscription): keep Pro plan until next release

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/grpc-ecosystem/go-grpc-middleware v1.4.0
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.22.0
 	github.com/influxdata/influxdb-client-go/v2 v2.12.3
-	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20250604083457-5b596b498aa8
+	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20250330053232-8078e4975698
 	github.com/instill-ai/usage-client v0.3.0-alpha.0.20250313022849-49504d982f18
 	github.com/instill-ai/x v0.8.0-alpha.0.20250522164415-9172edd336bb
 	github.com/knadh/koanf v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -351,8 +351,8 @@ github.com/influxdata/influxdb-client-go/v2 v2.12.3 h1:28nRlNMRIV4QbtIUvxhWqaxn0
 github.com/influxdata/influxdb-client-go/v2 v2.12.3/go.mod h1:IrrLUbCjjfkmRuaCiGQg4m2GbkaeJDcuWoxiWdQEbA0=
 github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839 h1:W9WBk7wlPfJLvMCdtV4zPulc4uCPrlywQOmbFOhgQNU=
 github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839/go.mod h1:xaLFMmpvUxqXtVkUJfg9QmT88cDaCJ3ZKgdZ78oO8Qo=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20250604083457-5b596b498aa8 h1:4UMWZOBg6eEat1H8DXg3OnBetVQOCgsvB3PGAbjgl/k=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20250604083457-5b596b498aa8/go.mod h1:bCnBosofpaUxKBuTTJM3/I3thAK37kvfBnKByjnLsl4=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20250330053232-8078e4975698 h1:1S3uhIUTODsVBTERxVK0BvnuCxoaninBPpuBhsFw6mw=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20250330053232-8078e4975698/go.mod h1:FuQL8siq3GgUFUlvKUKmLv3bgHxEVPeNfOZWQKRdPg0=
 github.com/instill-ai/usage-client v0.3.0-alpha.0.20250313022849-49504d982f18 h1:RFdRDODY4qMTTIcKm4TBMpYhxDGFCql6HQ7oocA+WeQ=
 github.com/instill-ai/usage-client v0.3.0-alpha.0.20250313022849-49504d982f18/go.mod h1:/B+Irg9TYBlP+X79GZ+yvPxFvC+7fbRL7APNGiJlDSk=
 github.com/instill-ai/x v0.8.0-alpha.0.20250522164415-9172edd336bb h1:lrHTet3MB9ctNTvY/H8qcyiHd1vdTRqzUMkGsh5/Pp8=

--- a/pkg/service/mgmt.go
+++ b/pkg/service/mgmt.go
@@ -77,7 +77,7 @@ func (s *Service) GetNamespaceTier(ctx context.Context, ns *resource.Namespace) 
 		}
 		if sub.GetSubscription().Plan == mgmtpb.UserSubscription_PLAN_FREE {
 			return TierFree, nil
-		} else if sub.GetSubscription().Plan == mgmtpb.UserSubscription_PLAN_STARTER {
+		} else if sub.GetSubscription().Plan == mgmtpb.UserSubscription_PLAN_PRO {
 			return TierPro, nil
 		}
 		return "", fmt.Errorf("unknown user subscription plan: %v", sub.GetSubscription().Plan)


### PR DESCRIPTION
Because

- There will be an `artifact-backend` release before `mgmt-backend` or
  `console` update the enum value for the Starter plan subscription.

This commit

- Reverts 304325c13ba46d29f55feea64d6127af1c654c9c to hold that change
  until a joint `instill-core` release is cut.
