### PR TITLE
feat(catalog): specify document conversion pipelines in catalog creation

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -22,7 +22,7 @@ database:
   host: pg-sql
   port: 5432
   name: artifact
-  version: 21
+  version: 22
   timezone: Etc/UTC
   pool:
     idleconnections: 5

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/grpc-ecosystem/go-grpc-middleware v1.4.0
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.22.0
 	github.com/influxdata/influxdb-client-go/v2 v2.12.3
-	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20250604083457-5b596b498aa8
+	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20250612072847-040eeef754c0
 	github.com/instill-ai/usage-client v0.3.0-alpha.0.20250313022849-49504d982f18
 	github.com/instill-ai/x v0.8.0-alpha.0.20250522164415-9172edd336bb
 	github.com/knadh/koanf v1.5.0
@@ -33,6 +33,7 @@ require (
 	go.opentelemetry.io/otel/sdk/metric v0.39.0
 	go.opentelemetry.io/otel/trace v1.16.0
 	go.uber.org/zap v1.26.0
+	golang.org/x/mod v0.17.0
 	golang.org/x/net v0.38.0
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240814211410-ddb44dafa142
 	google.golang.org/grpc v1.66.0
@@ -91,7 +92,7 @@ require (
 	github.com/jinzhu/now v1.1.5 // indirect
 	github.com/kr/pretty v0.3.1 // indirect
 	github.com/kr/text v0.2.0 // indirect
-	github.com/lib/pq v1.10.9 // indirect
+	github.com/lib/pq v1.10.9
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -351,8 +351,8 @@ github.com/influxdata/influxdb-client-go/v2 v2.12.3 h1:28nRlNMRIV4QbtIUvxhWqaxn0
 github.com/influxdata/influxdb-client-go/v2 v2.12.3/go.mod h1:IrrLUbCjjfkmRuaCiGQg4m2GbkaeJDcuWoxiWdQEbA0=
 github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839 h1:W9WBk7wlPfJLvMCdtV4zPulc4uCPrlywQOmbFOhgQNU=
 github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839/go.mod h1:xaLFMmpvUxqXtVkUJfg9QmT88cDaCJ3ZKgdZ78oO8Qo=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20250604083457-5b596b498aa8 h1:4UMWZOBg6eEat1H8DXg3OnBetVQOCgsvB3PGAbjgl/k=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20250604083457-5b596b498aa8/go.mod h1:bCnBosofpaUxKBuTTJM3/I3thAK37kvfBnKByjnLsl4=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20250612072847-040eeef754c0 h1:bjSw2oV62mLa+nGeoLp30uMYLNoA09Gl9MS4xOC4nXM=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20250612072847-040eeef754c0/go.mod h1:bCnBosofpaUxKBuTTJM3/I3thAK37kvfBnKByjnLsl4=
 github.com/instill-ai/usage-client v0.3.0-alpha.0.20250313022849-49504d982f18 h1:RFdRDODY4qMTTIcKm4TBMpYhxDGFCql6HQ7oocA+WeQ=
 github.com/instill-ai/usage-client v0.3.0-alpha.0.20250313022849-49504d982f18/go.mod h1:/B+Irg9TYBlP+X79GZ+yvPxFvC+7fbRL7APNGiJlDSk=
 github.com/instill-ai/x v0.8.0-alpha.0.20250522164415-9172edd336bb h1:lrHTet3MB9ctNTvY/H8qcyiHd1vdTRqzUMkGsh5/Pp8=

--- a/pkg/db/migration/000022_add_converting_pipelines_to_catalog.down.sql
+++ b/pkg/db/migration/000022_add_converting_pipelines_to_catalog.down.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+ALTER TABLE knowledge_base DROP COLUMN IF EXISTS converting_pipelines;
+
+COMMIT;

--- a/pkg/db/migration/000022_add_converting_pipelines_to_catalog.up.sql
+++ b/pkg/db/migration/000022_add_converting_pipelines_to_catalog.up.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+ALTER TABLE knowledge_base ADD COLUMN IF NOT EXISTS converting_pipelines VARCHAR(255)[];
+
+COMMIT;

--- a/pkg/handler/knowledgebase.go
+++ b/pkg/handler/knowledgebase.go
@@ -128,54 +128,60 @@ func (ph *PublicHandler) CreateCatalog(ctx context.Context, req *artifactpb.Crea
 		req.Type = artifactpb.CatalogType_CATALOG_TYPE_PERSISTENT
 	}
 
+	// Read conversion pipelines from request.
+	// TODO jvallesm: validate existence, permissions & recipe of provided
+	// pipelines.
+	convertingPipelines := req.GetConvertingPipelines()
+
 	// create catalog
 	dbData, err := ph.service.Repository.CreateKnowledgeBase(ctx,
 		repository.KnowledgeBase{
 			Name: req.Name,
 			// make name as kbID
-			KbID:        req.Name,
-			Description: req.Description,
-			Tags:        req.Tags,
-			Owner:       ns.NsUID.String(),
-			CreatorUID:  creatorUUID,
-			CatalogType: req.GetType().String(),
+			KbID:                req.Name,
+			Description:         req.Description,
+			Tags:                req.Tags,
+			Owner:               ns.NsUID.String(),
+			CreatorUID:          creatorUUID,
+			CatalogType:         req.GetType().String(),
+			ConvertingPipelines: convertingPipelines,
 		}, callExternalService,
 	)
 	if err != nil {
 		return nil, err
 	}
 
-	return &artifactpb.CreateCatalogResponse{
-		Catalog: &artifactpb.Catalog{
-			Name:        dbData.Name,
-			CatalogUid:  dbData.UID.String(),
-			CatalogId:   dbData.KbID,
-			Description: dbData.Description,
-			Tags:        dbData.Tags,
-			OwnerName:   dbData.Owner,
-			CreateTime:  dbData.CreateTime.String(),
-			UpdateTime:  dbData.UpdateTime.String(),
-			ConvertingPipelines: []string{
-				// Docling conversion is temporarily disabled.
-				// "instill/" + service.ConvertDocToMDModelID + "@" + service.ConvertDocToMDModelVersion,
-				service.ConvertDocToMDPipeline.Name(),
-			},
-			SummarizingPipelines: []string{
-				service.GenerateSummaryPipeline.Name(),
-			},
-			SplittingPipelines: []string{
-				service.ChunkTextPipeline.Name(),
-				service.ChunkMDPipeline.Name(),
-			},
-			EmbeddingPipelines: []string{
-				service.EmbedTextPipeline.Name(),
-			},
-			DownstreamApps: []string{},
-			TotalFiles:     0,
-			TotalTokens:    0,
-			UsedStorage:    0,
+	catalog := &artifactpb.Catalog{
+		Name:                dbData.Name,
+		CatalogUid:          dbData.UID.String(),
+		CatalogId:           dbData.KbID,
+		Description:         dbData.Description,
+		Tags:                dbData.Tags,
+		OwnerName:           dbData.Owner,
+		CreateTime:          dbData.CreateTime.String(),
+		UpdateTime:          dbData.UpdateTime.String(),
+		ConvertingPipelines: dbData.ConvertingPipelines,
+		SummarizingPipelines: []string{
+			service.GenerateSummaryPipeline.Name(),
 		},
-	}, nil
+		SplittingPipelines: []string{
+			service.ChunkTextPipeline.Name(),
+			service.ChunkMDPipeline.Name(),
+		},
+		EmbeddingPipelines: []string{
+			service.EmbedTextPipeline.Name(),
+		},
+		DownstreamApps: []string{},
+		TotalFiles:     0,
+		TotalTokens:    0,
+		UsedStorage:    0,
+	}
+
+	if len(dbData.ConvertingPipelines) == 0 {
+		catalog.ConvertingPipelines = defaultConvertingPipelines()
+	}
+
+	return &artifactpb.CreateCatalogResponse{Catalog: catalog}, nil
 }
 
 func (ph *PublicHandler) ListCatalogs(ctx context.Context, req *artifactpb.ListCatalogsRequest) (*artifactpb.ListCatalogsResponse, error) {
@@ -232,19 +238,15 @@ func (ph *PublicHandler) ListCatalogs(ctx context.Context, req *artifactpb.ListC
 	kbs := make([]*artifactpb.Catalog, len(dbData))
 	for i, kb := range dbData {
 		kbs[i] = &artifactpb.Catalog{
-			CatalogUid:  kb.UID.String(),
-			Name:        kb.Name,
-			CatalogId:   kb.KbID,
-			Description: kb.Description,
-			Tags:        kb.Tags,
-			CreateTime:  kb.CreateTime.String(),
-			UpdateTime:  kb.UpdateTime.String(),
-			OwnerName:   kb.Owner,
-			ConvertingPipelines: []string{
-				// Docling conversion is temporarily disabled.
-				// "instill/" + service.ConvertDocToMDModelID + "@" + service.ConvertDocToMDModelVersion,
-				service.ConvertDocToMDPipeline.Name(),
-			},
+			CatalogUid:          kb.UID.String(),
+			Name:                kb.Name,
+			CatalogId:           kb.KbID,
+			Description:         kb.Description,
+			Tags:                kb.Tags,
+			CreateTime:          kb.CreateTime.String(),
+			UpdateTime:          kb.UpdateTime.String(),
+			OwnerName:           kb.Owner,
+			ConvertingPipelines: kb.ConvertingPipelines,
 			SummarizingPipelines: []string{
 				service.GenerateSummaryPipeline.Name(),
 			},
@@ -260,6 +262,11 @@ func (ph *PublicHandler) ListCatalogs(ctx context.Context, req *artifactpb.ListC
 			TotalTokens:    uint32(tokenCounts[kb.UID]),
 			UsedStorage:    uint64(kb.Usage),
 		}
+
+		if len(kb.ConvertingPipelines) == 0 {
+			kbs[i].ConvertingPipelines = defaultConvertingPipelines()
+		}
+
 	}
 	return &artifactpb.ListCatalogsResponse{
 		Catalogs: kbs,
@@ -329,37 +336,38 @@ func (ph *PublicHandler) UpdateCatalog(ctx context.Context, req *artifactpb.Upda
 		log.Error("failed to get token counts", zap.Error(err))
 		return nil, fmt.Errorf(ErrorListKnowledgeBasesMsg, err)
 	}
+
 	// populate response
-	return &artifactpb.UpdateCatalogResponse{
-		Catalog: &artifactpb.Catalog{
-			Name:        kb.Name,
-			CatalogId:   kb.KbID,
-			Description: kb.Description,
-			Tags:        kb.Tags,
-			CreateTime:  kb.CreateTime.String(),
-			UpdateTime:  kb.UpdateTime.String(),
-			OwnerName:   kb.Owner,
-			ConvertingPipelines: []string{
-				// Docling conversion is temporarily disabled.
-				// "instill/" + service.ConvertDocToMDModelID + "@" + service.ConvertDocToMDModelVersion,
-				service.ConvertDocToMDPipeline.Name(),
-			},
-			SummarizingPipelines: []string{
-				service.GenerateSummaryPipeline.Name(),
-			},
-			SplittingPipelines: []string{
-				service.ChunkTextPipeline.Name(),
-				service.ChunkMDPipeline.Name(),
-			},
-			EmbeddingPipelines: []string{
-				service.EmbedTextPipeline.Name(),
-			},
-			DownstreamApps: []string{},
-			TotalFiles:     uint32(fileCounts[kb.UID]),
-			TotalTokens:    uint32(tokenCounts[kb.UID]),
-			UsedStorage:    uint64(kb.Usage),
+	catalog := &artifactpb.Catalog{
+		Name:                kb.Name,
+		CatalogId:           kb.KbID,
+		Description:         kb.Description,
+		Tags:                kb.Tags,
+		CreateTime:          kb.CreateTime.String(),
+		UpdateTime:          kb.UpdateTime.String(),
+		OwnerName:           kb.Owner,
+		ConvertingPipelines: kb.ConvertingPipelines,
+		SummarizingPipelines: []string{
+			service.GenerateSummaryPipeline.Name(),
 		},
-	}, nil
+		SplittingPipelines: []string{
+			service.ChunkTextPipeline.Name(),
+			service.ChunkMDPipeline.Name(),
+		},
+		EmbeddingPipelines: []string{
+			service.EmbedTextPipeline.Name(),
+		},
+		DownstreamApps: []string{},
+		TotalFiles:     uint32(fileCounts[kb.UID]),
+		TotalTokens:    uint32(tokenCounts[kb.UID]),
+		UsedStorage:    uint64(kb.Usage),
+	}
+
+	if len(kb.ConvertingPipelines) == 0 {
+		catalog.ConvertingPipelines = defaultConvertingPipelines()
+	}
+
+	return &artifactpb.UpdateCatalogResponse{Catalog: catalog}, nil
 }
 func (ph *PublicHandler) DeleteCatalog(ctx context.Context, req *artifactpb.DeleteCatalogRequest) (*artifactpb.DeleteCatalogResponse, error) {
 	log, _ := logger.GetZapLogger(ctx)
@@ -514,4 +522,16 @@ func generateID() string {
 	}
 
 	return string(id)
+}
+
+// defaultConvertingPipelines returns the converting pipelines used when the
+// catalog doesn't specify any. These aren't stored because they have custom
+// flows (e.g., triggering a model instead of a pipeline or passing extra
+// arguments).
+func defaultConvertingPipelines() []string {
+	return []string{
+		// Docling conversion is temporarily disabled.
+		// "instill/" + service.ConvertDocToMDModelID + "@" + service.ConvertDocToMDModelVersion,
+		service.ConvertDocToMDPipeline.Name(),
+	}
 }

--- a/pkg/mock/repository_i_mock.gen.go
+++ b/pkg/mock/repository_i_mock.gen.go
@@ -12,9 +12,9 @@ import (
 	"github.com/gojuno/minimock/v3"
 	mm_repository "github.com/instill-ai/artifact-backend/pkg/repository"
 	"github.com/instill-ai/artifact-backend/pkg/utils"
-	"gorm.io/gorm"
 	artifactpb "github.com/instill-ai/protogen-go/artifact/artifact/v1alpha"
 	pb "github.com/instill-ai/protogen-go/artifact/artifact/v1alpha"
+	"gorm.io/gorm"
 )
 
 // RepositoryIMock implements repository.RepositoryI
@@ -189,6 +189,12 @@ type RepositoryIMock struct {
 	afterGetKnowledgeBaseByOwnerAndKbIDCounter  uint64
 	beforeGetKnowledgeBaseByOwnerAndKbIDCounter uint64
 	GetKnowledgeBaseByOwnerAndKbIDMock          mRepositoryIMockGetKnowledgeBaseByOwnerAndKbID
+
+	funcGetKnowledgeBaseByUID          func(ctx context.Context, u1 uuid.UUID) (kp1 *mm_repository.KnowledgeBase, err error)
+	inspectFuncGetKnowledgeBaseByUID   func(ctx context.Context, u1 uuid.UUID)
+	afterGetKnowledgeBaseByUIDCounter  uint64
+	beforeGetKnowledgeBaseByUIDCounter uint64
+	GetKnowledgeBaseByUIDMock          mRepositoryIMockGetKnowledgeBaseByUID
 
 	funcGetKnowledgeBaseCountByOwner          func(ctx context.Context, ownerUID string, catalogType artifactpb.CatalogType) (i1 int64, err error)
 	inspectFuncGetKnowledgeBaseCountByOwner   func(ctx context.Context, ownerUID string, catalogType artifactpb.CatalogType)
@@ -539,6 +545,9 @@ func NewRepositoryIMock(t minimock.Tester) *RepositoryIMock {
 
 	m.GetKnowledgeBaseByOwnerAndKbIDMock = mRepositoryIMockGetKnowledgeBaseByOwnerAndKbID{mock: m}
 	m.GetKnowledgeBaseByOwnerAndKbIDMock.callArgs = []*RepositoryIMockGetKnowledgeBaseByOwnerAndKbIDParams{}
+
+	m.GetKnowledgeBaseByUIDMock = mRepositoryIMockGetKnowledgeBaseByUID{mock: m}
+	m.GetKnowledgeBaseByUIDMock.callArgs = []*RepositoryIMockGetKnowledgeBaseByUIDParams{}
 
 	m.GetKnowledgeBaseCountByOwnerMock = mRepositoryIMockGetKnowledgeBaseCountByOwner{mock: m}
 	m.GetKnowledgeBaseCountByOwnerMock.callArgs = []*RepositoryIMockGetKnowledgeBaseCountByOwnerParams{}
@@ -9539,6 +9548,327 @@ func (m *RepositoryIMock) MinimockGetKnowledgeBaseByOwnerAndKbIDInspect() {
 	if !m.GetKnowledgeBaseByOwnerAndKbIDMock.invocationsDone() && afterGetKnowledgeBaseByOwnerAndKbIDCounter > 0 {
 		m.t.Errorf("Expected %d calls to RepositoryIMock.GetKnowledgeBaseByOwnerAndKbID but found %d calls",
 			mm_atomic.LoadUint64(&m.GetKnowledgeBaseByOwnerAndKbIDMock.expectedInvocations), afterGetKnowledgeBaseByOwnerAndKbIDCounter)
+	}
+}
+
+type mRepositoryIMockGetKnowledgeBaseByUID struct {
+	optional           bool
+	mock               *RepositoryIMock
+	defaultExpectation *RepositoryIMockGetKnowledgeBaseByUIDExpectation
+	expectations       []*RepositoryIMockGetKnowledgeBaseByUIDExpectation
+
+	callArgs []*RepositoryIMockGetKnowledgeBaseByUIDParams
+	mutex    sync.RWMutex
+
+	expectedInvocations uint64
+}
+
+// RepositoryIMockGetKnowledgeBaseByUIDExpectation specifies expectation struct of the RepositoryI.GetKnowledgeBaseByUID
+type RepositoryIMockGetKnowledgeBaseByUIDExpectation struct {
+	mock      *RepositoryIMock
+	params    *RepositoryIMockGetKnowledgeBaseByUIDParams
+	paramPtrs *RepositoryIMockGetKnowledgeBaseByUIDParamPtrs
+	results   *RepositoryIMockGetKnowledgeBaseByUIDResults
+	Counter   uint64
+}
+
+// RepositoryIMockGetKnowledgeBaseByUIDParams contains parameters of the RepositoryI.GetKnowledgeBaseByUID
+type RepositoryIMockGetKnowledgeBaseByUIDParams struct {
+	ctx context.Context
+	u1  uuid.UUID
+}
+
+// RepositoryIMockGetKnowledgeBaseByUIDParamPtrs contains pointers to parameters of the RepositoryI.GetKnowledgeBaseByUID
+type RepositoryIMockGetKnowledgeBaseByUIDParamPtrs struct {
+	ctx *context.Context
+	u1  *uuid.UUID
+}
+
+// RepositoryIMockGetKnowledgeBaseByUIDResults contains results of the RepositoryI.GetKnowledgeBaseByUID
+type RepositoryIMockGetKnowledgeBaseByUIDResults struct {
+	kp1 *mm_repository.KnowledgeBase
+	err error
+}
+
+// Marks this method to be optional. The default behavior of any method with Return() is '1 or more', meaning
+// the test will fail minimock's automatic final call check if the mocked method was not called at least once.
+// Optional() makes method check to work in '0 or more' mode.
+// It is NOT RECOMMENDED to use this option unless you really need it, as default behaviour helps to
+// catch the problems when the expected method call is totally skipped during test run.
+func (mmGetKnowledgeBaseByUID *mRepositoryIMockGetKnowledgeBaseByUID) Optional() *mRepositoryIMockGetKnowledgeBaseByUID {
+	mmGetKnowledgeBaseByUID.optional = true
+	return mmGetKnowledgeBaseByUID
+}
+
+// Expect sets up expected params for RepositoryI.GetKnowledgeBaseByUID
+func (mmGetKnowledgeBaseByUID *mRepositoryIMockGetKnowledgeBaseByUID) Expect(ctx context.Context, u1 uuid.UUID) *mRepositoryIMockGetKnowledgeBaseByUID {
+	if mmGetKnowledgeBaseByUID.mock.funcGetKnowledgeBaseByUID != nil {
+		mmGetKnowledgeBaseByUID.mock.t.Fatalf("RepositoryIMock.GetKnowledgeBaseByUID mock is already set by Set")
+	}
+
+	if mmGetKnowledgeBaseByUID.defaultExpectation == nil {
+		mmGetKnowledgeBaseByUID.defaultExpectation = &RepositoryIMockGetKnowledgeBaseByUIDExpectation{}
+	}
+
+	if mmGetKnowledgeBaseByUID.defaultExpectation.paramPtrs != nil {
+		mmGetKnowledgeBaseByUID.mock.t.Fatalf("RepositoryIMock.GetKnowledgeBaseByUID mock is already set by ExpectParams functions")
+	}
+
+	mmGetKnowledgeBaseByUID.defaultExpectation.params = &RepositoryIMockGetKnowledgeBaseByUIDParams{ctx, u1}
+	for _, e := range mmGetKnowledgeBaseByUID.expectations {
+		if minimock.Equal(e.params, mmGetKnowledgeBaseByUID.defaultExpectation.params) {
+			mmGetKnowledgeBaseByUID.mock.t.Fatalf("Expectation set by When has same params: %#v", *mmGetKnowledgeBaseByUID.defaultExpectation.params)
+		}
+	}
+
+	return mmGetKnowledgeBaseByUID
+}
+
+// ExpectCtxParam1 sets up expected param ctx for RepositoryI.GetKnowledgeBaseByUID
+func (mmGetKnowledgeBaseByUID *mRepositoryIMockGetKnowledgeBaseByUID) ExpectCtxParam1(ctx context.Context) *mRepositoryIMockGetKnowledgeBaseByUID {
+	if mmGetKnowledgeBaseByUID.mock.funcGetKnowledgeBaseByUID != nil {
+		mmGetKnowledgeBaseByUID.mock.t.Fatalf("RepositoryIMock.GetKnowledgeBaseByUID mock is already set by Set")
+	}
+
+	if mmGetKnowledgeBaseByUID.defaultExpectation == nil {
+		mmGetKnowledgeBaseByUID.defaultExpectation = &RepositoryIMockGetKnowledgeBaseByUIDExpectation{}
+	}
+
+	if mmGetKnowledgeBaseByUID.defaultExpectation.params != nil {
+		mmGetKnowledgeBaseByUID.mock.t.Fatalf("RepositoryIMock.GetKnowledgeBaseByUID mock is already set by Expect")
+	}
+
+	if mmGetKnowledgeBaseByUID.defaultExpectation.paramPtrs == nil {
+		mmGetKnowledgeBaseByUID.defaultExpectation.paramPtrs = &RepositoryIMockGetKnowledgeBaseByUIDParamPtrs{}
+	}
+	mmGetKnowledgeBaseByUID.defaultExpectation.paramPtrs.ctx = &ctx
+
+	return mmGetKnowledgeBaseByUID
+}
+
+// ExpectU1Param2 sets up expected param u1 for RepositoryI.GetKnowledgeBaseByUID
+func (mmGetKnowledgeBaseByUID *mRepositoryIMockGetKnowledgeBaseByUID) ExpectU1Param2(u1 uuid.UUID) *mRepositoryIMockGetKnowledgeBaseByUID {
+	if mmGetKnowledgeBaseByUID.mock.funcGetKnowledgeBaseByUID != nil {
+		mmGetKnowledgeBaseByUID.mock.t.Fatalf("RepositoryIMock.GetKnowledgeBaseByUID mock is already set by Set")
+	}
+
+	if mmGetKnowledgeBaseByUID.defaultExpectation == nil {
+		mmGetKnowledgeBaseByUID.defaultExpectation = &RepositoryIMockGetKnowledgeBaseByUIDExpectation{}
+	}
+
+	if mmGetKnowledgeBaseByUID.defaultExpectation.params != nil {
+		mmGetKnowledgeBaseByUID.mock.t.Fatalf("RepositoryIMock.GetKnowledgeBaseByUID mock is already set by Expect")
+	}
+
+	if mmGetKnowledgeBaseByUID.defaultExpectation.paramPtrs == nil {
+		mmGetKnowledgeBaseByUID.defaultExpectation.paramPtrs = &RepositoryIMockGetKnowledgeBaseByUIDParamPtrs{}
+	}
+	mmGetKnowledgeBaseByUID.defaultExpectation.paramPtrs.u1 = &u1
+
+	return mmGetKnowledgeBaseByUID
+}
+
+// Inspect accepts an inspector function that has same arguments as the RepositoryI.GetKnowledgeBaseByUID
+func (mmGetKnowledgeBaseByUID *mRepositoryIMockGetKnowledgeBaseByUID) Inspect(f func(ctx context.Context, u1 uuid.UUID)) *mRepositoryIMockGetKnowledgeBaseByUID {
+	if mmGetKnowledgeBaseByUID.mock.inspectFuncGetKnowledgeBaseByUID != nil {
+		mmGetKnowledgeBaseByUID.mock.t.Fatalf("Inspect function is already set for RepositoryIMock.GetKnowledgeBaseByUID")
+	}
+
+	mmGetKnowledgeBaseByUID.mock.inspectFuncGetKnowledgeBaseByUID = f
+
+	return mmGetKnowledgeBaseByUID
+}
+
+// Return sets up results that will be returned by RepositoryI.GetKnowledgeBaseByUID
+func (mmGetKnowledgeBaseByUID *mRepositoryIMockGetKnowledgeBaseByUID) Return(kp1 *mm_repository.KnowledgeBase, err error) *RepositoryIMock {
+	if mmGetKnowledgeBaseByUID.mock.funcGetKnowledgeBaseByUID != nil {
+		mmGetKnowledgeBaseByUID.mock.t.Fatalf("RepositoryIMock.GetKnowledgeBaseByUID mock is already set by Set")
+	}
+
+	if mmGetKnowledgeBaseByUID.defaultExpectation == nil {
+		mmGetKnowledgeBaseByUID.defaultExpectation = &RepositoryIMockGetKnowledgeBaseByUIDExpectation{mock: mmGetKnowledgeBaseByUID.mock}
+	}
+	mmGetKnowledgeBaseByUID.defaultExpectation.results = &RepositoryIMockGetKnowledgeBaseByUIDResults{kp1, err}
+	return mmGetKnowledgeBaseByUID.mock
+}
+
+// Set uses given function f to mock the RepositoryI.GetKnowledgeBaseByUID method
+func (mmGetKnowledgeBaseByUID *mRepositoryIMockGetKnowledgeBaseByUID) Set(f func(ctx context.Context, u1 uuid.UUID) (kp1 *mm_repository.KnowledgeBase, err error)) *RepositoryIMock {
+	if mmGetKnowledgeBaseByUID.defaultExpectation != nil {
+		mmGetKnowledgeBaseByUID.mock.t.Fatalf("Default expectation is already set for the RepositoryI.GetKnowledgeBaseByUID method")
+	}
+
+	if len(mmGetKnowledgeBaseByUID.expectations) > 0 {
+		mmGetKnowledgeBaseByUID.mock.t.Fatalf("Some expectations are already set for the RepositoryI.GetKnowledgeBaseByUID method")
+	}
+
+	mmGetKnowledgeBaseByUID.mock.funcGetKnowledgeBaseByUID = f
+	return mmGetKnowledgeBaseByUID.mock
+}
+
+// When sets expectation for the RepositoryI.GetKnowledgeBaseByUID which will trigger the result defined by the following
+// Then helper
+func (mmGetKnowledgeBaseByUID *mRepositoryIMockGetKnowledgeBaseByUID) When(ctx context.Context, u1 uuid.UUID) *RepositoryIMockGetKnowledgeBaseByUIDExpectation {
+	if mmGetKnowledgeBaseByUID.mock.funcGetKnowledgeBaseByUID != nil {
+		mmGetKnowledgeBaseByUID.mock.t.Fatalf("RepositoryIMock.GetKnowledgeBaseByUID mock is already set by Set")
+	}
+
+	expectation := &RepositoryIMockGetKnowledgeBaseByUIDExpectation{
+		mock:   mmGetKnowledgeBaseByUID.mock,
+		params: &RepositoryIMockGetKnowledgeBaseByUIDParams{ctx, u1},
+	}
+	mmGetKnowledgeBaseByUID.expectations = append(mmGetKnowledgeBaseByUID.expectations, expectation)
+	return expectation
+}
+
+// Then sets up RepositoryI.GetKnowledgeBaseByUID return parameters for the expectation previously defined by the When method
+func (e *RepositoryIMockGetKnowledgeBaseByUIDExpectation) Then(kp1 *mm_repository.KnowledgeBase, err error) *RepositoryIMock {
+	e.results = &RepositoryIMockGetKnowledgeBaseByUIDResults{kp1, err}
+	return e.mock
+}
+
+// Times sets number of times RepositoryI.GetKnowledgeBaseByUID should be invoked
+func (mmGetKnowledgeBaseByUID *mRepositoryIMockGetKnowledgeBaseByUID) Times(n uint64) *mRepositoryIMockGetKnowledgeBaseByUID {
+	if n == 0 {
+		mmGetKnowledgeBaseByUID.mock.t.Fatalf("Times of RepositoryIMock.GetKnowledgeBaseByUID mock can not be zero")
+	}
+	mm_atomic.StoreUint64(&mmGetKnowledgeBaseByUID.expectedInvocations, n)
+	return mmGetKnowledgeBaseByUID
+}
+
+func (mmGetKnowledgeBaseByUID *mRepositoryIMockGetKnowledgeBaseByUID) invocationsDone() bool {
+	if len(mmGetKnowledgeBaseByUID.expectations) == 0 && mmGetKnowledgeBaseByUID.defaultExpectation == nil && mmGetKnowledgeBaseByUID.mock.funcGetKnowledgeBaseByUID == nil {
+		return true
+	}
+
+	totalInvocations := mm_atomic.LoadUint64(&mmGetKnowledgeBaseByUID.mock.afterGetKnowledgeBaseByUIDCounter)
+	expectedInvocations := mm_atomic.LoadUint64(&mmGetKnowledgeBaseByUID.expectedInvocations)
+
+	return totalInvocations > 0 && (expectedInvocations == 0 || expectedInvocations == totalInvocations)
+}
+
+// GetKnowledgeBaseByUID implements repository.RepositoryI
+func (mmGetKnowledgeBaseByUID *RepositoryIMock) GetKnowledgeBaseByUID(ctx context.Context, u1 uuid.UUID) (kp1 *mm_repository.KnowledgeBase, err error) {
+	mm_atomic.AddUint64(&mmGetKnowledgeBaseByUID.beforeGetKnowledgeBaseByUIDCounter, 1)
+	defer mm_atomic.AddUint64(&mmGetKnowledgeBaseByUID.afterGetKnowledgeBaseByUIDCounter, 1)
+
+	if mmGetKnowledgeBaseByUID.inspectFuncGetKnowledgeBaseByUID != nil {
+		mmGetKnowledgeBaseByUID.inspectFuncGetKnowledgeBaseByUID(ctx, u1)
+	}
+
+	mm_params := RepositoryIMockGetKnowledgeBaseByUIDParams{ctx, u1}
+
+	// Record call args
+	mmGetKnowledgeBaseByUID.GetKnowledgeBaseByUIDMock.mutex.Lock()
+	mmGetKnowledgeBaseByUID.GetKnowledgeBaseByUIDMock.callArgs = append(mmGetKnowledgeBaseByUID.GetKnowledgeBaseByUIDMock.callArgs, &mm_params)
+	mmGetKnowledgeBaseByUID.GetKnowledgeBaseByUIDMock.mutex.Unlock()
+
+	for _, e := range mmGetKnowledgeBaseByUID.GetKnowledgeBaseByUIDMock.expectations {
+		if minimock.Equal(*e.params, mm_params) {
+			mm_atomic.AddUint64(&e.Counter, 1)
+			return e.results.kp1, e.results.err
+		}
+	}
+
+	if mmGetKnowledgeBaseByUID.GetKnowledgeBaseByUIDMock.defaultExpectation != nil {
+		mm_atomic.AddUint64(&mmGetKnowledgeBaseByUID.GetKnowledgeBaseByUIDMock.defaultExpectation.Counter, 1)
+		mm_want := mmGetKnowledgeBaseByUID.GetKnowledgeBaseByUIDMock.defaultExpectation.params
+		mm_want_ptrs := mmGetKnowledgeBaseByUID.GetKnowledgeBaseByUIDMock.defaultExpectation.paramPtrs
+
+		mm_got := RepositoryIMockGetKnowledgeBaseByUIDParams{ctx, u1}
+
+		if mm_want_ptrs != nil {
+
+			if mm_want_ptrs.ctx != nil && !minimock.Equal(*mm_want_ptrs.ctx, mm_got.ctx) {
+				mmGetKnowledgeBaseByUID.t.Errorf("RepositoryIMock.GetKnowledgeBaseByUID got unexpected parameter ctx, want: %#v, got: %#v%s\n", *mm_want_ptrs.ctx, mm_got.ctx, minimock.Diff(*mm_want_ptrs.ctx, mm_got.ctx))
+			}
+
+			if mm_want_ptrs.u1 != nil && !minimock.Equal(*mm_want_ptrs.u1, mm_got.u1) {
+				mmGetKnowledgeBaseByUID.t.Errorf("RepositoryIMock.GetKnowledgeBaseByUID got unexpected parameter u1, want: %#v, got: %#v%s\n", *mm_want_ptrs.u1, mm_got.u1, minimock.Diff(*mm_want_ptrs.u1, mm_got.u1))
+			}
+
+		} else if mm_want != nil && !minimock.Equal(*mm_want, mm_got) {
+			mmGetKnowledgeBaseByUID.t.Errorf("RepositoryIMock.GetKnowledgeBaseByUID got unexpected parameters, want: %#v, got: %#v%s\n", *mm_want, mm_got, minimock.Diff(*mm_want, mm_got))
+		}
+
+		mm_results := mmGetKnowledgeBaseByUID.GetKnowledgeBaseByUIDMock.defaultExpectation.results
+		if mm_results == nil {
+			mmGetKnowledgeBaseByUID.t.Fatal("No results are set for the RepositoryIMock.GetKnowledgeBaseByUID")
+		}
+		return (*mm_results).kp1, (*mm_results).err
+	}
+	if mmGetKnowledgeBaseByUID.funcGetKnowledgeBaseByUID != nil {
+		return mmGetKnowledgeBaseByUID.funcGetKnowledgeBaseByUID(ctx, u1)
+	}
+	mmGetKnowledgeBaseByUID.t.Fatalf("Unexpected call to RepositoryIMock.GetKnowledgeBaseByUID. %v %v", ctx, u1)
+	return
+}
+
+// GetKnowledgeBaseByUIDAfterCounter returns a count of finished RepositoryIMock.GetKnowledgeBaseByUID invocations
+func (mmGetKnowledgeBaseByUID *RepositoryIMock) GetKnowledgeBaseByUIDAfterCounter() uint64 {
+	return mm_atomic.LoadUint64(&mmGetKnowledgeBaseByUID.afterGetKnowledgeBaseByUIDCounter)
+}
+
+// GetKnowledgeBaseByUIDBeforeCounter returns a count of RepositoryIMock.GetKnowledgeBaseByUID invocations
+func (mmGetKnowledgeBaseByUID *RepositoryIMock) GetKnowledgeBaseByUIDBeforeCounter() uint64 {
+	return mm_atomic.LoadUint64(&mmGetKnowledgeBaseByUID.beforeGetKnowledgeBaseByUIDCounter)
+}
+
+// Calls returns a list of arguments used in each call to RepositoryIMock.GetKnowledgeBaseByUID.
+// The list is in the same order as the calls were made (i.e. recent calls have a higher index)
+func (mmGetKnowledgeBaseByUID *mRepositoryIMockGetKnowledgeBaseByUID) Calls() []*RepositoryIMockGetKnowledgeBaseByUIDParams {
+	mmGetKnowledgeBaseByUID.mutex.RLock()
+
+	argCopy := make([]*RepositoryIMockGetKnowledgeBaseByUIDParams, len(mmGetKnowledgeBaseByUID.callArgs))
+	copy(argCopy, mmGetKnowledgeBaseByUID.callArgs)
+
+	mmGetKnowledgeBaseByUID.mutex.RUnlock()
+
+	return argCopy
+}
+
+// MinimockGetKnowledgeBaseByUIDDone returns true if the count of the GetKnowledgeBaseByUID invocations corresponds
+// the number of defined expectations
+func (m *RepositoryIMock) MinimockGetKnowledgeBaseByUIDDone() bool {
+	if m.GetKnowledgeBaseByUIDMock.optional {
+		// Optional methods provide '0 or more' call count restriction.
+		return true
+	}
+
+	for _, e := range m.GetKnowledgeBaseByUIDMock.expectations {
+		if mm_atomic.LoadUint64(&e.Counter) < 1 {
+			return false
+		}
+	}
+
+	return m.GetKnowledgeBaseByUIDMock.invocationsDone()
+}
+
+// MinimockGetKnowledgeBaseByUIDInspect logs each unmet expectation
+func (m *RepositoryIMock) MinimockGetKnowledgeBaseByUIDInspect() {
+	for _, e := range m.GetKnowledgeBaseByUIDMock.expectations {
+		if mm_atomic.LoadUint64(&e.Counter) < 1 {
+			m.t.Errorf("Expected call to RepositoryIMock.GetKnowledgeBaseByUID with params: %#v", *e.params)
+		}
+	}
+
+	afterGetKnowledgeBaseByUIDCounter := mm_atomic.LoadUint64(&m.afterGetKnowledgeBaseByUIDCounter)
+	// if default expectation was set then invocations count should be greater than zero
+	if m.GetKnowledgeBaseByUIDMock.defaultExpectation != nil && afterGetKnowledgeBaseByUIDCounter < 1 {
+		if m.GetKnowledgeBaseByUIDMock.defaultExpectation.params == nil {
+			m.t.Error("Expected call to RepositoryIMock.GetKnowledgeBaseByUID")
+		} else {
+			m.t.Errorf("Expected call to RepositoryIMock.GetKnowledgeBaseByUID with params: %#v", *m.GetKnowledgeBaseByUIDMock.defaultExpectation.params)
+		}
+	}
+	// if func was set then invocations count should be greater than zero
+	if m.funcGetKnowledgeBaseByUID != nil && afterGetKnowledgeBaseByUIDCounter < 1 {
+		m.t.Error("Expected call to RepositoryIMock.GetKnowledgeBaseByUID")
+	}
+
+	if !m.GetKnowledgeBaseByUIDMock.invocationsDone() && afterGetKnowledgeBaseByUIDCounter > 0 {
+		m.t.Errorf("Expected %d calls to RepositoryIMock.GetKnowledgeBaseByUID but found %d calls",
+			mm_atomic.LoadUint64(&m.GetKnowledgeBaseByUIDMock.expectedInvocations), afterGetKnowledgeBaseByUIDCounter)
 	}
 }
 
@@ -23671,6 +24001,8 @@ func (m *RepositoryIMock) MinimockFinish() {
 
 			m.MinimockGetKnowledgeBaseByOwnerAndKbIDInspect()
 
+			m.MinimockGetKnowledgeBaseByUIDInspect()
+
 			m.MinimockGetKnowledgeBaseCountByOwnerInspect()
 
 			m.MinimockGetKnowledgeBaseFilesByFileUIDsInspect()
@@ -23804,6 +24136,7 @@ func (m *RepositoryIMock) minimockDone() bool {
 		m.MinimockGetEmbeddingByUIDsDone() &&
 		m.MinimockGetFilesTotalTokensDone() &&
 		m.MinimockGetKnowledgeBaseByOwnerAndKbIDDone() &&
+		m.MinimockGetKnowledgeBaseByUIDDone() &&
 		m.MinimockGetKnowledgeBaseCountByOwnerDone() &&
 		m.MinimockGetKnowledgeBaseFilesByFileUIDsDone() &&
 		m.MinimockGetKnowledgeBasesByUIDsDone() &&

--- a/pkg/service/pipeline_test.go
+++ b/pkg/service/pipeline_test.go
@@ -1,0 +1,77 @@
+package service
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+)
+
+func TestPipelineReleaseFromName(t *testing.T) {
+	c := qt.New(t)
+
+	testcases := []struct {
+		name    string
+		input   string
+		want    PipelineRelease
+		wantErr string
+	}{
+		{
+			name:  "ok - valid pipeline release name",
+			input: "namespace/pipeline@v1.0.0",
+			want: PipelineRelease{
+				Namespace: "namespace",
+				ID:        "pipeline",
+				Version:   "v1.0.0",
+			},
+		},
+		{
+			name:  "ok - valid pipeline release name with complex version",
+			input: "my-namespace/my-pipeline@v1.2.3-beta",
+			want: PipelineRelease{
+				Namespace: "my-namespace",
+				ID:        "my-pipeline",
+				Version:   "v1.2.3-beta",
+			},
+		},
+		{
+			name:    "nok - missing namespace",
+			input:   "pipeline@v1.0.0",
+			wantErr: "name must have the format {namespace}/{id}@{version}",
+		},
+		{
+			name:    "nok - missing version",
+			input:   "namespace/pipeline",
+			wantErr: "name must have the format {namespace}/{id}@{version}",
+		},
+		{
+			name:    "nok - empty string",
+			input:   "",
+			wantErr: "name must have the format {namespace}/{id}@{version}",
+		},
+		{
+			name:    "nok - invalid format with multiple @",
+			input:   "namespace/pipeline@v1.0.0@extra",
+			wantErr: "name must have the format {namespace}/{id}@{version}",
+		},
+		{
+			name:    "nok - invalid format with multiple /",
+			input:   "namespace/sub/pipeline@v1.0.0",
+			wantErr: "name must have the format {namespace}/{id}@{version}",
+		},
+	}
+
+	for _, tc := range testcases {
+		c.Run(tc.name, func(c *qt.C) {
+			got, err := PipelineReleaseFromName(tc.input)
+
+			if tc.wantErr != "" {
+				c.Check(err, qt.IsNotNil)
+				c.Check(err.Error(), qt.Equals, tc.wantErr)
+				return
+			}
+
+			c.Check(err, qt.IsNil)
+			c.Check(got, qt.DeepEquals, tc.want)
+		})
+	}
+}

--- a/pkg/worker/persistentcatalogworker.go
+++ b/pkg/worker/persistentcatalogworker.go
@@ -399,15 +399,39 @@ func (wp *persistentCatalogFileToEmbWorkerPool) processConvertingFile(ctx contex
 	logger, _ := logger.GetZapLogger(ctx)
 
 	fileInMinIOPath := file.Destination
+
+	// TODO jvallesm: we should only return errors in these child methods and
+	// centralize logging in wp.processFile.
+	logger = logger.With(
+		zap.String("fileUID", file.UID.String()),
+		zap.String("filePath", fileInMinIOPath),
+	)
+
 	bucket := checkIfUploadedByBlobURL(fileInMinIOPath)
 	data, err := wp.svc.MinIO.GetFile(ctx, bucket, fileInMinIOPath)
 	if err != nil {
-		logger.Error("Failed to get file from minIO.", zap.String("File path", fileInMinIOPath))
+		logger.Error("Failed to get file from minIO")
 		return nil, artifactpb.FileProcessStatus_FILE_PROCESS_STATUS_UNSPECIFIED, err
 	}
 
 	// encode data to base64
 	base64Data := base64.StdEncoding.EncodeToString(data)
+
+	// Read converting pipelines from catalog.
+	kb, err := wp.svc.Repository.GetKnowledgeBaseByUID(ctx, file.KnowledgeBaseUID)
+	if err != nil {
+		return nil, artifactpb.FileProcessStatus_FILE_PROCESS_STATUS_UNSPECIFIED, fmt.Errorf("fetching parent catalog: %w", err)
+	}
+
+	convertingPipelines := make([]service.PipelineRelease, 0, len(kb.ConvertingPipelines))
+	for _, pipelineName := range kb.ConvertingPipelines {
+		pipeline, err := service.PipelineReleaseFromName(pipelineName)
+		if err != nil {
+			return nil, artifactpb.FileProcessStatus_FILE_PROCESS_STATUS_UNSPECIFIED, fmt.Errorf("parsing pipeline name: %w", err)
+		}
+
+		convertingPipelines = append(convertingPipelines, pipeline)
+	}
 
 	// convert the pdf file to md
 	var convertedMD string
@@ -423,22 +447,28 @@ func (wp *persistentCatalogFileToEmbWorkerPool) processConvertingFile(ctx contex
 			if err != nil {
 				logger.Error("Failed to convert pdf to md using docling model, fallback to pipeline.")
 				if convertedMD, err = wp.svc.ConvertToMDPipe(ctx, file.UID, base64Data, artifactpb.FileType(artifactpb.FileType_value[file.Type])); err != nil {
-					logger.Error("Failed to convert pdf to md using pdf-to-md pipeline.", zap.String("File path", fileInMinIOPath))
+					logger.Error("Failed to convert pdf to md using pdf-to-md pipeline")
 					return nil, artifactpb.FileProcessStatus_FILE_PROCESS_STATUS_UNSPECIFIED, err
 				}
 			}
 	*/
 	default:
-		if convertedMD, err = wp.svc.ConvertToMDPipe(ctx, file.UID, base64Data, artifactpb.FileType(artifactpb.FileType_value[file.Type])); err != nil {
-			logger.Error("Failed to convert pdf to md using pdf-to-md pipeline.", zap.String("File path", fileInMinIOPath))
-			return nil, artifactpb.FileProcessStatus_FILE_PROCESS_STATUS_UNSPECIFIED, err
+		convertedMD, err = wp.svc.ConvertToMDPipe(
+			ctx,
+			file.UID,
+			base64Data,
+			artifactpb.FileType(artifactpb.FileType_value[file.Type]),
+			convertingPipelines,
+		)
+		if err != nil {
+			return nil, artifactpb.FileProcessStatus_FILE_PROCESS_STATUS_UNSPECIFIED, fmt.Errorf("converting file to Markdown: %w", err)
 		}
 	}
 
 	// save the converted file into object storage and metadata into database
 	err = saveConvertedFile(ctx, wp.svc, file.KnowledgeBaseUID, file.UID, "converted_"+file.Name, []byte(convertedMD))
 	if err != nil {
-		logger.Error("Failed to save converted data.", zap.String("File path", fileInMinIOPath))
+		logger.Error("Failed to save converted data")
 		return nil, artifactpb.FileProcessStatus_FILE_PROCESS_STATUS_UNSPECIFIED, err
 	}
 	// update the file status to chunking status in database
@@ -447,7 +477,7 @@ func (wp *persistentCatalogFileToEmbWorkerPool) processConvertingFile(ctx contex
 	}
 	updatedFile, err = wp.svc.Repository.UpdateKnowledgeBaseFile(ctx, file.UID.String(), updateMap)
 	if err != nil {
-		logger.Error("Failed to update file status.", zap.String("File uid", file.UID.String()))
+		logger.Error("Failed to update file status")
 		return nil, artifactpb.FileProcessStatus_FILE_PROCESS_STATUS_UNSPECIFIED, err
 	}
 


### PR DESCRIPTION
Because

- Some catalogs require custom document conversion.

This commit

- Adds a parameter in the catalog creation endpoint that allows users to
  define a list of pipelines to be used during document conversion. They'll
  be executed in order until one returns a successful, non-empty response.
