### PR TITLE
ci(workflow): update the dockerhub credentials and docker version in ga workflow

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -22,7 +22,7 @@ jobs:
         uses: docker/setup-buildx-action@v2
 
       - name: Login to DockerHub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: drop@instill-ai.com
           password: ${{ secrets.botDockerHubPassword }}

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Login to DockerHub
         uses: docker/login-action@v2
         with:
-          username: dropletbot
+          username: drop@instill-ai.com
           password: ${{ secrets.botDockerHubPassword }}
 
       - name: Build and push (latest)


### PR DESCRIPTION
Because

- We have updated the login credentials from drop@instill.tech to drop@instill-ai.com in dockerhub.

This commit

- update the dockerhub credentials and docker version  in ga workflow
