### PR TITLE
fix(preset): use docling converter in document component

### DIFF
--- a/pkg/service/preset/pipelines/indexing-advanced-convert-doc/v1.3.1/recipe.yaml
+++ b/pkg/service/preset/pipelines/indexing-advanced-convert-doc/v1.3.1/recipe.yaml
@@ -20,6 +20,7 @@ component:
     task: TASK_CONVERT_TO_MARKDOWN
     input:
       document: ${variable.document_input}
+      converter: docling
   batch-images:
     type: collection
     input:

--- a/pkg/service/preset/pipelines/indexing-convert-pdf/v1.1.1/recipe.yaml
+++ b/pkg/service/preset/pipelines/indexing-convert-pdf/v1.1.1/recipe.yaml
@@ -5,6 +5,7 @@ component:
     task: TASK_CONVERT_TO_MARKDOWN
     input:
       document: ${variable.document_input}
+      converter: docling
 variable:
   document_input:
     title: document-input


### PR DESCRIPTION
Because

- the pdfplumber converter is not robust.

This commit

- use Docling converter in document component
