### PR TITLE
chore(conversion): fallback to heuristic method on parsing-router pipeline

### DIFF
--- a/pkg/service/preset/pipelines/parsing-router/v1.0.0/recipe.yaml
+++ b/pkg/service/preset/pipelines/parsing-router/v1.0.0/recipe.yaml
@@ -88,6 +88,9 @@ component:
     input:
       string: ${router.output.texts[0]}
     task: TASK_UNMARSHAL
+  # The heuristic component will be executed regardless of the router output.
+  # It will be used to refine the VLM method, or as a fallback for the Docling
+  # method if the model is offline.
   heuristic:
     type: document
     task: TASK_CONVERT_TO_MARKDOWN
@@ -97,7 +100,6 @@ component:
       display-all-page-image: false
       resolution: 300
       converter: pdfplumber
-    condition: ${string-to-json.output.json.selectedCategory} != "Docling Model"
   get-encoded-images:
     type: iterator
     input: ${pages-to-images.output.images}


### PR DESCRIPTION
Because

- Sometimes Docling model will be offline and we want to yield a result
  (even if sub-optimal) in that scenario.

This commit

- Makes the `parsing-router` pipeline execute the heuristic method
  regardless the routing output.
- Uses the heuristic output as the default conversion result, then
  checks for the results of the routed method.
