### PR TITLE
chore(dep): bump up usage-client version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/grpc-ecosystem/go-grpc-middleware v1.4.0
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.26.3
 	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20250701144349-953c6318807e
-	github.com/instill-ai/usage-client v0.3.0-alpha.0.20250626142928-89526ea95ca7
+	github.com/instill-ai/usage-client v0.4.0
 	github.com/instill-ai/x v0.8.0-alpha.0.20250630064356-d3b28166753a
 	github.com/knadh/koanf v1.5.0
 	github.com/milvus-io/milvus-sdk-go/v2 v2.4.1

--- a/go.sum
+++ b/go.sum
@@ -277,6 +277,8 @@ github.com/instill-ai/protogen-go v0.3.3-alpha.0.20250701144349-953c6318807e h1:
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20250701144349-953c6318807e/go.mod h1:bCnBosofpaUxKBuTTJM3/I3thAK37kvfBnKByjnLsl4=
 github.com/instill-ai/usage-client v0.3.0-alpha.0.20250626142928-89526ea95ca7 h1:qAZD/iDAjRw6MEnqsVO1qJaYw3sK2gfXoce8eZ9tJy0=
 github.com/instill-ai/usage-client v0.3.0-alpha.0.20250626142928-89526ea95ca7/go.mod h1:zZ9LRoXps2u63ARYPAbR2YvqTib3dWJLObZn+9YqhF0=
+github.com/instill-ai/usage-client v0.4.0 h1:xf1hAlO4a8lZwZzz9bprZOJqU3ghIcIsavUUB7UURyg=
+github.com/instill-ai/usage-client v0.4.0/go.mod h1:zZ9LRoXps2u63ARYPAbR2YvqTib3dWJLObZn+9YqhF0=
 github.com/instill-ai/x v0.8.0-alpha.0.20250630064356-d3b28166753a h1:d8et7U05o3Fd8yOtVVetep0hJgquEYzNylHYVe/QQ/s=
 github.com/instill-ai/x v0.8.0-alpha.0.20250630064356-d3b28166753a/go.mod h1:y4oWSeaaH05iJqZyVQ1WRujNnlt4fGbkCpGlbN19apQ=
 github.com/iris-contrib/blackfriday v2.0.0+incompatible/go.mod h1:UzZ2bDEoaSGPbkg6SAB4att1aAwTmVIx/5gCVqeyUdI=


### PR DESCRIPTION
Because

- usage-client has a a new version to adopt the latest services

This commit

- bumps up the usage-client version