### PR TITLE
fix(service): fix the wrong object size

### DIFF
--- a/pkg/minio/minio.go
+++ b/pkg/minio/minio.go
@@ -33,6 +33,8 @@ type MinioI interface {
 	GetFile(ctx context.Context, bucket string, filePath string) ([]byte, error)
 	// GetFilesByPaths
 	GetFilesByPaths(ctx context.Context, bucket string, filePaths []string) ([]FileContent, error)
+	// GetFileMetadata: get the metadata of the file
+	GetFileMetadata(ctx context.Context, bucket string, filePath string) (*minio.ObjectInfo, error)
 	// KnowledgeBase
 	KnowledgeBaseI
 	// Object
@@ -217,6 +219,14 @@ func (m *Minio) GetFile(ctx context.Context, bucket string, filePathName string)
 	}
 
 	return buf.Bytes(), nil
+}
+
+func (m *Minio) GetFileMetadata(ctx context.Context, bucket string, filePathName string) (*minio.ObjectInfo, error) {
+	object, err := m.client.StatObject(ctx, bucket, filePathName, minio.StatObjectOptions{})
+	if err != nil {
+		return nil, err
+	}
+	return &object, nil
 }
 
 // FileContent represents a file and its content

--- a/pkg/service/object.go
+++ b/pkg/service/object.go
@@ -156,13 +156,15 @@ func (s *service) GetDownloadURL(
 			return nil, ErrObjectNotUploaded
 		}
 
-		_, err := s.minIO.GetFile(ctx, miniolocal.BlobBucketName, object.Destination)
+		objectInfo, err := s.minIO.GetFileMetadata(ctx, miniolocal.BlobBucketName, object.Destination)
 		if err != nil {
 			log.Error("failed to get file", zap.Error(err))
 			return nil, status.Errorf(codes.Internal, "failed to get file: %v", err)
 		}
 		object.IsUploaded = true
-
+		object.Size = objectInfo.Size
+		object.LastModifiedTime = &objectInfo.LastModified
+		object.ContentType = objectInfo.ContentType
 	}
 
 	// Check URL expiration days


### PR DESCRIPTION
Because

- the object metadata was not correct when returning the object download link.

This commit

- fixes the wrong object metadata.
