### PR TITLE
ci(deps): upgrade x package

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -66,14 +66,20 @@ jobs:
         uses: docker/login-action@v3
         with:
           username: drop@instill-ai.com
-          password: ${{ secrets.BOTDOCKERHUBPASSWORD }}
+          password: ${{ secrets.botDockerHubPassword }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
       - name: Set short commit SHA
+        if: github.ref == 'refs/heads/main'
         run: |
-          echo "COMMIT_SHORT_SHA=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+          echo "COMMIT_SHORT_SHA=${GITHUB_SHA:0:7}" >> $GITHUB_ENV
+
+      - name: Set PR head commit SHA
+        if: github.event_name == 'pull_request'
+        run: |
+          echo "COMMIT_SHORT_SHA=$(echo ${{ github.event.pull_request.head.sha }} | cut -c1-7)" >> $GITHUB_ENV
 
       - name: Build image
         uses: docker/build-push-action@v6
@@ -81,7 +87,7 @@ jobs:
           context: artifact-backend
           load: true
           build-args: |
-            SERVICE_NAME=artifact-backend
+            SERVICE_NAME=${{ env.SERVICE_NAME }}
             SERVICE_VERSION=${{ env.COMMIT_SHORT_SHA }}
           tags: instill/artifact-backend:latest
           cache-from: |

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.1
 	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20250707160902-77023eb2f033
 	github.com/instill-ai/usage-client v0.4.0
-	github.com/instill-ai/x v0.8.0-alpha.0.20250714023551-3829fd844cd5
+	github.com/instill-ai/x v0.9.0-alpha
 	github.com/knadh/koanf v1.5.0
 	github.com/milvus-io/milvus-sdk-go/v2 v2.4.1
 	github.com/minio/minio-go/v7 v7.0.92

--- a/go.sum
+++ b/go.sum
@@ -275,6 +275,8 @@ github.com/instill-ai/usage-client v0.4.0 h1:xf1hAlO4a8lZwZzz9bprZOJqU3ghIcIsavU
 github.com/instill-ai/usage-client v0.4.0/go.mod h1:zZ9LRoXps2u63ARYPAbR2YvqTib3dWJLObZn+9YqhF0=
 github.com/instill-ai/x v0.8.0-alpha.0.20250714023551-3829fd844cd5 h1:2iy0ssXScON7XgFLLR4NUSjYszpXfPbMUlmPNPXppzY=
 github.com/instill-ai/x v0.8.0-alpha.0.20250714023551-3829fd844cd5/go.mod h1:RXY1NPBMxe3K7bBecPALw+Af2dT+gJSb89BOlLIPfx4=
+github.com/instill-ai/x v0.9.0-alpha h1:J11sJNMe39GAQ69tPy7OWV/hBD39oyF+4wHB1fKiwvw=
+github.com/instill-ai/x v0.9.0-alpha/go.mod h1:vAzbuQ7HAWdQkkpDq9mvWjSXQEJZSgJhguN6NhpLTUk=
 github.com/iris-contrib/blackfriday v2.0.0+incompatible/go.mod h1:UzZ2bDEoaSGPbkg6SAB4att1aAwTmVIx/5gCVqeyUdI=
 github.com/iris-contrib/go.uuid v2.0.0+incompatible/go.mod h1:iz2lgM/1UnEf1kP0L/+fafWORmlnuysV2EMP8MW+qe0=
 github.com/iris-contrib/jade v1.1.3/go.mod h1:H/geBymxJhShH5kecoiOCSssPX7QWYH7UaeZTSWddIk=


### PR DESCRIPTION
Because

- the `x` package has a major update to catch up
- the latest instrument logic in the `x/client` and `x/server` package can be easily adopted. 

This commit

- upgrade `x` package
- fix a minor CI step error.
