### PR TITLE
chore(mgmt): use new subscription states

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/google/go-cmp v0.7.0
 	github.com/grpc-ecosystem/go-grpc-middleware v1.4.0
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.1
-	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20250707160902-77023eb2f033
+	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20250715074516-b9b6e1aab1a9
 	github.com/instill-ai/usage-client v0.4.0
 	github.com/instill-ai/x v0.9.0-alpha
 	github.com/knadh/koanf v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -269,12 +269,10 @@ github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpO
 github.com/hydrogen18/memlistener v0.0.0-20200120041712-dcc25e7acd91/go.mod h1:qEIFzExnS6016fRpRfxrExeVn2gbClQA99gQhnIcdhE=
 github.com/imkira/go-interpol v1.1.0/go.mod h1:z0h2/2T3XF8kyEPpRgJ3kmNv+C43p+I/CoI+jC3w2iA=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20250707160902-77023eb2f033 h1:jhP9Gz7tw57rTTHQ7WhHOWf7z/worMcfr/n3NAcjbD4=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20250707160902-77023eb2f033/go.mod h1:bCnBosofpaUxKBuTTJM3/I3thAK37kvfBnKByjnLsl4=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20250715074516-b9b6e1aab1a9 h1:ucqjrLRP9V1LhE1ScrI6cSKD60pR1VIgrMMCm+pecDE=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20250715074516-b9b6e1aab1a9/go.mod h1:bCnBosofpaUxKBuTTJM3/I3thAK37kvfBnKByjnLsl4=
 github.com/instill-ai/usage-client v0.4.0 h1:xf1hAlO4a8lZwZzz9bprZOJqU3ghIcIsavUUB7UURyg=
 github.com/instill-ai/usage-client v0.4.0/go.mod h1:zZ9LRoXps2u63ARYPAbR2YvqTib3dWJLObZn+9YqhF0=
-github.com/instill-ai/x v0.8.0-alpha.0.20250714023551-3829fd844cd5 h1:2iy0ssXScON7XgFLLR4NUSjYszpXfPbMUlmPNPXppzY=
-github.com/instill-ai/x v0.8.0-alpha.0.20250714023551-3829fd844cd5/go.mod h1:RXY1NPBMxe3K7bBecPALw+Af2dT+gJSb89BOlLIPfx4=
 github.com/instill-ai/x v0.9.0-alpha h1:J11sJNMe39GAQ69tPy7OWV/hBD39oyF+4wHB1fKiwvw=
 github.com/instill-ai/x v0.9.0-alpha/go.mod h1:vAzbuQ7HAWdQkkpDq9mvWjSXQEJZSgJhguN6NhpLTUk=
 github.com/iris-contrib/blackfriday v2.0.0+incompatible/go.mod h1:UzZ2bDEoaSGPbkg6SAB4att1aAwTmVIx/5gCVqeyUdI=

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -27,7 +27,6 @@ type Service interface {
 	QuestionAnsweringPipe(_ context.Context, question string, simChunks []string) (string, error)
 	SimilarityChunksSearch(_ context.Context, ownerUID uuid.UUID, _ *artifactpb.SimilarityChunksSearchRequest) ([]SimChunk, error)
 	GetNamespaceByNsID(_ context.Context, nsID string) (*resource.Namespace, error)
-	GetNamespaceTierByNsID(_ context.Context, nsID string) (Tier, error)
 	GetNamespaceTier(context.Context, *resource.Namespace) (Tier, error)
 	GetChunksByFile(context.Context, *repository.KnowledgeBaseFile) (SourceTableType, SourceIDType, []repository.TextChunk, map[ChunkUIDType]ContentType, []string, error)
 	ListRepositoryTags(context.Context, *artifactpb.ListRepositoryTagsRequest) (*artifactpb.ListRepositoryTagsResponse, error)


### PR DESCRIPTION
Because

- `mgmt`'s API has updated the enum values for the subscription statuses

This commit

- Removes the free plan enum from the client and, instead, interprets
  the zero value or the paid plans with non-active statuses as the free
  plan.
