### PR TITLE
ci(github): trigger instill-core sync after image build

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -49,7 +49,7 @@ jobs:
         run: |
           echo "COMMIT_SHORT_SHA=${GITHUB_SHA:0:7}" >> $GITHUB_ENV
 
-      - name: Build and push amd64 (latest)
+      - name: Build and push amd64 (commit hash)
         if: github.ref == 'refs/heads/main'
         uses: docker/build-push-action@v6
         with:
@@ -59,7 +59,7 @@ jobs:
           build-args: |
             SERVICE_NAME=${{ env.SERVICE_NAME }}
             SERVICE_VERSION=${{ env.COMMIT_SHORT_SHA }}
-          tags: instill/${{ env.SERVICE_NAME }}:latest-amd64
+          tags: instill/${{ env.SERVICE_NAME }}:${{ env.COMMIT_SHORT_SHA }}-amd64
           cache-from: type=registry,ref=instill/${{ env.SERVICE_NAME }}:buildcache
           cache-to: type=registry,ref=instill/${{ env.SERVICE_NAME }}:buildcache,mode=max
 
@@ -124,7 +124,7 @@ jobs:
         run: |
           echo "COMMIT_SHORT_SHA=${GITHUB_SHA:0:7}" >> $GITHUB_ENV
 
-      - name: Build and push arm64 (latest)
+      - name: Build and push arm64 (commit hash)
         if: github.ref == 'refs/heads/main'
         uses: docker/build-push-action@v6
         with:
@@ -134,7 +134,7 @@ jobs:
           build-args: |
             SERVICE_NAME=${{ env.SERVICE_NAME }}
             SERVICE_VERSION=${{ env.COMMIT_SHORT_SHA }}
-          tags: instill/${{ env.SERVICE_NAME }}:latest-arm64
+          tags: instill/${{ env.SERVICE_NAME }}:${{ env.COMMIT_SHORT_SHA }}-arm64
           cache-from: type=registry,ref=instill/${{ env.SERVICE_NAME }}:buildcache
           cache-to: type=registry,ref=instill/${{ env.SERVICE_NAME }}:buildcache,mode=max
 
@@ -182,12 +182,24 @@ jobs:
           username: drop@instill-ai.com
           password: ${{ secrets.botDockerHubPassword }}
 
+      - name: Set short commit SHA
+        if: github.ref == 'refs/heads/main'
+        run: |
+          echo "COMMIT_SHORT_SHA=${GITHUB_SHA:0:7}" >> $GITHUB_ENV
+
+      - name: Create and push multi-arch manifest (commit hash)
+        if: github.ref == 'refs/heads/main'
+        run: |
+          docker buildx imagetools create -t instill/${{ env.SERVICE_NAME }}:${{ env.COMMIT_SHORT_SHA }} \
+            instill/${{ env.SERVICE_NAME }}:${{ env.COMMIT_SHORT_SHA }}-amd64 \
+            instill/${{ env.SERVICE_NAME }}:${{ env.COMMIT_SHORT_SHA }}-arm64
+
       - name: Create and push multi-arch manifest (latest)
         if: github.ref == 'refs/heads/main'
         run: |
           docker buildx imagetools create -t instill/${{ env.SERVICE_NAME }}:latest \
-            instill/${{ env.SERVICE_NAME }}:latest-amd64 \
-            instill/${{ env.SERVICE_NAME }}:latest-arm64
+            instill/${{ env.SERVICE_NAME }}:${{ env.COMMIT_SHORT_SHA }}-amd64 \
+            instill/${{ env.SERVICE_NAME }}:${{ env.COMMIT_SHORT_SHA }}-arm64
 
       - name: Set Versions
         if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'release'

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -89,13 +89,13 @@ jobs:
           build-args: |
             SERVICE_NAME=${{ env.SERVICE_NAME }}
             SERVICE_VERSION=${{ env.COMMIT_SHORT_SHA }}
-          tags: instill/artifact-backend:latest
+          tags: instill/artifact-backend:${{ env.COMMIT_SHORT_SHA }}
           cache-from: |
             type=registry,ref=instill/artifact-backend:buildcache
           cache-to: |
             type=registry,ref=instill/artifact-backend:buildcache,mode=max
 
-      - name: Launch Instill Core CE (latest)
+      - name: Launch Instill Core CE (commit hash)
         working-directory: instill-core
         run: |
           make latest EDITION=docker-ce:test ENV_SECRETS_COMPONENT=.env.secrets.component.test

--- a/.github/workflows/sync-instill-core.yml
+++ b/.github/workflows/sync-instill-core.yml
@@ -1,0 +1,18 @@
+name: Sync Instill Core Version
+
+on:
+  workflow_run:
+    workflows: ["Build and Push Images"]
+    types:
+      - completed
+    branches:
+      - main
+
+jobs:
+  update-version:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    uses: instill-ai/instill-core/.github/workflows/update-service-version.yml@main
+    with:
+      service: artifact
+    secrets:
+      botGitHubToken: ${{ secrets.botGitHubToken }}


### PR DESCRIPTION
Because

- we want to automatically sync the image hash or tag to the instill-core repository.

This commit

- triggers the instill-core sync after the image is built.