### PR TITLE
fix(service): the user without tier will fallback to TierFree

### DIFF
--- a/pkg/service/mgmt.go
+++ b/pkg/service/mgmt.go
@@ -75,6 +75,8 @@ func (s *service) GetNamespaceTier(ctx context.Context, ns *resource.Namespace) 
 			default:
 				return TierFree, nil
 			}
+		default:
+			return TierFree, nil
 		}
 	case resource.Organization:
 		sub, err := s.mgmtPrv.GetOrganizationSubscriptionAdmin(ctx, &pb.GetOrganizationSubscriptionAdminRequest{


### PR DESCRIPTION
Because

- The condition in GetNamespaceTier didn’t handle the unspecified plan.

This commit

- Ensures that users without a tier will fall back to TierFree.