### PR TITLE
feat(embedding): filter embedding search with file UID list

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/google/go-cmp v0.7.0
 	github.com/grpc-ecosystem/go-grpc-middleware v1.4.0
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.1
-	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20250819073725-8350bd9a6b18
+	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20250819103430-ead45d938b76
 	github.com/instill-ai/usage-client v0.4.0
 	github.com/instill-ai/x v0.9.0-alpha
 	github.com/knadh/koanf v1.5.0

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/google/go-cmp v0.7.0
 	github.com/grpc-ecosystem/go-grpc-middleware v1.4.0
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.1
-	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20250715074516-b9b6e1aab1a9
+	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20250819073725-8350bd9a6b18
 	github.com/instill-ai/usage-client v0.4.0
 	github.com/instill-ai/x v0.9.0-alpha
 	github.com/knadh/koanf v1.5.0

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/instill-ai/usage-client v0.4.0
 	github.com/instill-ai/x v0.9.0-alpha
 	github.com/knadh/koanf v1.5.0
-	github.com/milvus-io/milvus-sdk-go/v2 v2.4.1
+	github.com/milvus-io/milvus-sdk-go/v2 v2.4.2
 	github.com/minio/minio-go/v7 v7.0.92
 	github.com/openfga/api/proto v0.0.0-20240723155248-7e5be7b65c27
 	github.com/redis/go-redis/v9 v9.9.0
@@ -52,6 +52,7 @@ require (
 	go.opentelemetry.io/otel/sdk/metric v1.37.0 // indirect
 	go.opentelemetry.io/otel/trace v1.37.0 // indirect
 	go.temporal.io/sdk v1.34.0 // indirect
+	golang.org/x/sync v0.15.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250603155806-513f23925822 // indirect
 )
 
@@ -93,7 +94,7 @@ require (
 	github.com/kr/pretty v0.3.1 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/lib/pq v1.10.9
-	github.com/milvus-io/milvus-proto/go-api/v2 v2.4.3 // indirect
+	github.com/milvus-io/milvus-proto/go-api/v2 v2.4.10-0.20240819025435-512e3b98866a // indirect
 	github.com/minio/crc64nvme v1.0.2 // indirect
 	github.com/minio/md5-simd v1.1.2 // indirect
 	github.com/mitchellh/copystructure v1.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -269,8 +269,8 @@ github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpO
 github.com/hydrogen18/memlistener v0.0.0-20200120041712-dcc25e7acd91/go.mod h1:qEIFzExnS6016fRpRfxrExeVn2gbClQA99gQhnIcdhE=
 github.com/imkira/go-interpol v1.1.0/go.mod h1:z0h2/2T3XF8kyEPpRgJ3kmNv+C43p+I/CoI+jC3w2iA=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20250715074516-b9b6e1aab1a9 h1:ucqjrLRP9V1LhE1ScrI6cSKD60pR1VIgrMMCm+pecDE=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20250715074516-b9b6e1aab1a9/go.mod h1:bCnBosofpaUxKBuTTJM3/I3thAK37kvfBnKByjnLsl4=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20250819073725-8350bd9a6b18 h1:xI0smpwSR/7YYWV1gL2W5bZtdsz+tCCHVFdPqC3InYU=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20250819073725-8350bd9a6b18/go.mod h1:bCnBosofpaUxKBuTTJM3/I3thAK37kvfBnKByjnLsl4=
 github.com/instill-ai/usage-client v0.4.0 h1:xf1hAlO4a8lZwZzz9bprZOJqU3ghIcIsavUUB7UURyg=
 github.com/instill-ai/usage-client v0.4.0/go.mod h1:zZ9LRoXps2u63ARYPAbR2YvqTib3dWJLObZn+9YqhF0=
 github.com/instill-ai/x v0.9.0-alpha h1:J11sJNMe39GAQ69tPy7OWV/hBD39oyF+4wHB1fKiwvw=

--- a/go.sum
+++ b/go.sum
@@ -269,8 +269,8 @@ github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpO
 github.com/hydrogen18/memlistener v0.0.0-20200120041712-dcc25e7acd91/go.mod h1:qEIFzExnS6016fRpRfxrExeVn2gbClQA99gQhnIcdhE=
 github.com/imkira/go-interpol v1.1.0/go.mod h1:z0h2/2T3XF8kyEPpRgJ3kmNv+C43p+I/CoI+jC3w2iA=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20250819073725-8350bd9a6b18 h1:xI0smpwSR/7YYWV1gL2W5bZtdsz+tCCHVFdPqC3InYU=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20250819073725-8350bd9a6b18/go.mod h1:bCnBosofpaUxKBuTTJM3/I3thAK37kvfBnKByjnLsl4=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20250819103430-ead45d938b76 h1:Ytb1B0YBhQbop8pl6h5UKK7tIlEYCaqSy2WcIVk+8Qc=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20250819103430-ead45d938b76/go.mod h1:bCnBosofpaUxKBuTTJM3/I3thAK37kvfBnKByjnLsl4=
 github.com/instill-ai/usage-client v0.4.0 h1:xf1hAlO4a8lZwZzz9bprZOJqU3ghIcIsavUUB7UURyg=
 github.com/instill-ai/usage-client v0.4.0/go.mod h1:zZ9LRoXps2u63ARYPAbR2YvqTib3dWJLObZn+9YqhF0=
 github.com/instill-ai/x v0.9.0-alpha h1:J11sJNMe39GAQ69tPy7OWV/hBD39oyF+4wHB1fKiwvw=

--- a/go.sum
+++ b/go.sum
@@ -414,10 +414,10 @@ github.com/mediocregopher/radix/v3 v3.4.2/go.mod h1:8FL3F6UQRXHXIBSPUs5h0RybMF8i
 github.com/microcosm-cc/bluemonday v1.0.2/go.mod h1:iVP4YcDBq+n/5fb23BhYFvIMq/leAFZyRl6bYmGDlGc=
 github.com/miekg/dns v1.1.26/go.mod h1:bPDLeHnStXmXAq1m/Ch/hvfNHr14JKNPMBo3VZKjuso=
 github.com/miekg/dns v1.1.41/go.mod h1:p6aan82bvRIyn+zDIv9xYNUpwa73JcSh9BKwknJysuI=
-github.com/milvus-io/milvus-proto/go-api/v2 v2.4.3 h1:KUSaWVePVlHMIluAXf2qmNffI1CMlGFLLiP+4iy9014=
-github.com/milvus-io/milvus-proto/go-api/v2 v2.4.3/go.mod h1:1OIl0v5PQeNxIJhCvY+K55CBUOYDZevw9g9380u1Wek=
-github.com/milvus-io/milvus-sdk-go/v2 v2.4.1 h1:KhqjmaJE4mSxj1a88XtkGaqgH4duGiHs1sjnvSXkwE0=
-github.com/milvus-io/milvus-sdk-go/v2 v2.4.1/go.mod h1:7SJxshlnVhNLksS73tLPtHYY9DiX7lyL43Rv41HCPCw=
+github.com/milvus-io/milvus-proto/go-api/v2 v2.4.10-0.20240819025435-512e3b98866a h1:0B/8Fo66D8Aa23Il0yrQvg1KKz92tE/BJ5BvkUxxAAk=
+github.com/milvus-io/milvus-proto/go-api/v2 v2.4.10-0.20240819025435-512e3b98866a/go.mod h1:1OIl0v5PQeNxIJhCvY+K55CBUOYDZevw9g9380u1Wek=
+github.com/milvus-io/milvus-sdk-go/v2 v2.4.2 h1:Xqf+S7iicElwYoS2Zly8Nf/zKHuZsNy1xQajfdtygVY=
+github.com/milvus-io/milvus-sdk-go/v2 v2.4.2/go.mod h1:ulO1YUXKH0PGg50q27grw048GDY9ayB4FPmh7D+FFTA=
 github.com/minio/crc64nvme v1.0.2 h1:6uO1UxGAD+kwqWWp7mBFsi5gAse66C4NXO8cmcVculg=
 github.com/minio/crc64nvme v1.0.2/go.mod h1:eVfm2fAzLlxMdUGc0EEBGSMmPwmXD5XiNRpnu9J3bvg=
 github.com/minio/md5-simd v1.1.2 h1:Gdi1DZK69+ZVMoNHRXJyNcxrMA4dSxoYHZSQbirFg34=

--- a/pkg/handler/qa.go
+++ b/pkg/handler/qa.go
@@ -16,12 +16,12 @@ import (
 	logx "github.com/instill-ai/x/log"
 )
 
+// QuestionAnswering provides the response to the prompted question, returning
+// contextual information like the chunks used to build the answer.
 func (ph *PublicHandler) QuestionAnswering(
 	ctx context.Context,
-	req *artifactPb.QuestionAnsweringRequest) (
-	*artifactPb.QuestionAnsweringResponse,
-	error) {
-
+	req *artifactPb.QuestionAnsweringRequest,
+) (*artifactPb.QuestionAnsweringResponse, error) {
 	logger, _ := logx.GetZapLogger(ctx)
 
 	t := time.Now()
@@ -64,6 +64,7 @@ func (ph *PublicHandler) QuestionAnswering(
 		TopK:        uint32(req.GetTopK()),
 		CatalogId:   req.GetCatalogId(),
 		NamespaceId: req.GetNamespaceId(),
+		FileUids:    req.GetFileUids(),
 	}
 
 	simChunksScores, err := ph.service.SimilarityChunksSearch(ctx, ownerUID, scReq)

--- a/pkg/handler/retrieval.go
+++ b/pkg/handler/retrieval.go
@@ -18,100 +18,100 @@ import (
 	logx "github.com/instill-ai/x/log"
 )
 
+// SimilarityChunksSearch rturns the top-K most similar chunks to a text
+// prompt.
 func (ph *PublicHandler) SimilarityChunksSearch(
 	ctx context.Context,
 	req *artifactpb.SimilarityChunksSearchRequest,
 ) (*artifactpb.SimilarityChunksSearchResponse, error) {
 	logger, _ := logx.GetZapLogger(ctx)
+	logger = logger.With(
+		zap.String("namespace", req.GetNamespaceId()),
+		zap.String("catalog", req.GetCatalogId()),
+	)
 
-	t := time.Now()
 	ns, err := ph.service.GetNamespaceByNsID(ctx, req.GetNamespaceId())
 	if err != nil {
-		logger.Error("failed to get namespace by ns id", zap.Error(err))
-		return nil, fmt.Errorf("failed to get namespace by ns id. err: %w", err)
+		return nil, fmt.Errorf("fetching namespace: %w", err)
 	}
-	logger.Info("get namespace by ns id", zap.Duration("duration", time.Since(t)))
-	t = time.Now()
+
 	ownerUID := ns.NsUID
 	kb, err := ph.service.Repository().GetKnowledgeBaseByOwnerAndKbID(ctx, ownerUID, req.CatalogId)
 	if err != nil {
-		logger.Error("failed to get catalog by owner and kb id", zap.Error(err))
-		return nil, fmt.Errorf("failed to get catalog by owner and kb id. err: %w", err)
+		return nil, fmt.Errorf("fetching catalog: %w", err)
 	}
-	logger.Info("get catalog by owner and kb id", zap.Duration("duration", time.Since(t)))
-	t = time.Now()
+
 	// ACL : check user has access to the catalog
 	granted, err := ph.service.ACLClient().CheckPermission(ctx, "knowledgebase", kb.UID, "reader")
 	if err != nil {
-		logger.Error("failed to check permission", zap.Error(err))
-		return nil, fmt.Errorf("failed to check permission. err: %w", err)
+		return nil, fmt.Errorf("checking permissions: %w", err)
 	}
 	if !granted {
-		return nil, fmt.Errorf("SimilarityChunksSearch permission denied. err: %w", errorsx.ErrUnauthenticated)
+		return nil, errorsx.ErrUnauthenticated
 	}
-	logger.Info("check permission", zap.Duration("duration", time.Since(t)))
-	t = time.Now()
+
 	// check auth user has access to the requester
 	err = ph.service.ACLClient().CheckRequesterPermission(ctx)
 	if err != nil {
-		logger.Error("failed to check requester permission", zap.Error(err))
-		return nil, fmt.Errorf("failed to check requester permission. err: %w", err)
+		return nil, fmt.Errorf("checking requester permission: %w", err)
 	}
+
 	// retrieve the chunks based on the similarity
+	t := time.Now()
 	simChunksScores, err := ph.service.SimilarityChunksSearch(ctx, ownerUID, req)
 	if err != nil {
-		logger.Error("failed to get similarity chunks", zap.Error(err))
-		return nil, fmt.Errorf("failed to get similarity chunks. err: %w", err)
+		return nil, fmt.Errorf("searching similar chunks: %w", err)
 	}
 	var chunkUIDs []uuid.UUID
 	for _, simChunk := range simChunksScores {
 		chunkUIDs = append(chunkUIDs, simChunk.ChunkUID)
 	}
 	logger.Info("get similarity chunks", zap.Duration("duration", time.Since(t)))
-	t = time.Now()
+
 	// fetch the chunks metadata
 	chunks, err := ph.service.Repository().GetChunksByUIDs(ctx, chunkUIDs)
 	if err != nil {
-		logger.Error("failed to get chunks by uids", zap.Error(err))
-		return nil, fmt.Errorf("failed to get chunks by uids. err: %w", err)
+		return nil, fmt.Errorf("fetching chunk metadata: %w", err)
 	}
+
 	// chunks content
 	chunkFilePaths := make([]string, 0, len(chunks))
 	for _, chunk := range chunks {
 		chunkFilePaths = append(chunkFilePaths, chunk.ContentDest)
 	}
-	logger.Info("get chunks by uids", zap.Duration("duration", time.Since(t)))
-	t = time.Now()
-	// fetch the chunks content from minio
+
+	// fetch the chunks content from blob storage
 	chunkContents, err := ph.service.MinIO().GetFilesByPaths(ctx, minio.KnowledgeBaseBucketName, chunkFilePaths)
 	if err != nil {
-		logger.Error("failed to get chunks content", zap.Error(err))
-		return nil, fmt.Errorf("failed to get chunks content. err: %w", err)
+		return nil, fmt.Errorf("fetching chunk contents: %w", err)
 	}
-	logger.Info("get chunks content from minIO", zap.Duration("duration", time.Since(t)))
 
 	// fetch the file names
 	fileUIDMapName := make(map[uuid.UUID]string)
 	for _, chunk := range chunks {
 		fileUIDMapName[chunk.KbFileUID] = ""
 	}
+
 	fileUids := make([]uuid.UUID, 0, len(fileUIDMapName))
 	for fileUID := range fileUIDMapName {
 		fileUids = append(fileUids, fileUID)
 	}
-	t = time.Now()
+
 	files, err := ph.service.Repository().GetKnowledgeBaseFilesByFileUIDs(
-		ctx, fileUids, repository.KnowledgeBaseFileColumn.UID, repository.KnowledgeBaseFileColumn.Name)
+		ctx,
+		fileUids,
+		repository.KnowledgeBaseFileColumn.UID,
+		repository.KnowledgeBaseFileColumn.Name,
+	)
 	if err != nil {
-		logger.Error("failed to get catalog files by file uids", zap.Error(err))
-		return nil, fmt.Errorf("failed to get catalog files by file uids. err: %w", err)
+		return nil, fmt.Errorf("fetching file info: %w", err)
 	}
+
 	for _, file := range files {
 		fileUIDMapName[file.UID] = file.Name
 	}
-	logger.Info("get catalog files by file uids", zap.Duration("duration", time.Since(t)))
 
-	// prepare the response
+	// build response
 	simChunks := make([]*artifactpb.SimilarityChunk, 0, len(chunks))
 	for i, chunk := range chunks {
 		if !chunk.Retrievable {
@@ -146,5 +146,6 @@ func (ph *PublicHandler) SimilarityChunksSearch(
 			},
 		})
 	}
+
 	return &artifactpb.SimilarityChunksSearchResponse{SimilarChunks: simChunks}, nil
 }

--- a/pkg/milvus/milvus.go
+++ b/pkg/milvus/milvus.go
@@ -216,16 +216,27 @@ func (m *milvusClient) DeleteEmbeddingsInCollection(ctx context.Context, collect
 	return err
 }
 
+func (m *milvusClient) fileUIDFilter(fileUIDs []uuid.UUID) string {
+	validUIDs := make([]string, 0, len(fileUIDs))
+	for _, uid := range fileUIDs {
+		if uid.IsNil() {
+			continue
+		}
+		validUIDs = append(validUIDs, `"`+uid.String()+`"`)
+	}
+
+	if len(validUIDs) == 0 {
+		return ""
+	}
+
+	return fmt.Sprintf("%s in [%s]", kbCollectionFieldFileUID, strings.Join(validUIDs, ","))
+}
+
 func (m *milvusClient) SimilarVectorsInCollection(ctx context.Context, p service.SimilarVectorSearchParam) ([][]service.SimilarEmbedding, error) {
 	logger, _ := logx.GetZapLogger(ctx)
 
 	collectionName := p.CollectionID
-	vectors := p.Vectors
 	topK := int(p.TopK)
-	fileUID := p.FileUID
-	fileName := p.FileName
-	fileType := p.FileType
-	contentType := p.ContentType
 
 	logger = logger.With(zap.String("collection_name", collectionName))
 
@@ -270,28 +281,33 @@ func (m *milvusClient) SimilarVectorsInCollection(ctx context.Context, p service
 		)
 
 		if hasFileUID {
-			if fileUID != uuid.Nil {
-				filterStrs = append(filterStrs, fmt.Sprintf("%s == '%s'", kbCollectionFieldFileUID, fileUID.String()))
-			}
 			outputFields = append(outputFields, kbCollectionFieldFileUID)
-		} else if fileName != "" {
-			filterStrs = append(filterStrs, fmt.Sprintf("%s == '%s'", kbCollectionFieldFileName, fileName))
+
+			filter := m.fileUIDFilter(p.FileUIDs)
+			if filter != "" {
+				filterStrs = append(filterStrs, filter)
+			}
+		} else if len(p.FileNames) > 0 {
+			// Filename filter is only used for backwards compatibility in
+			// collections that lack the file UID metadata.
+			filter := fmt.Sprintf(`%s in ["%s"]`, kbCollectionFieldFileName, strings.Join(p.FileNames, `","`))
+			filterStrs = append(filterStrs, filter)
 		}
 
-		if fileType != "" {
-			filterStrs = append(filterStrs, fmt.Sprintf("%s == '%s'", kbCollectionFieldFileType, fileType))
+		if p.FileType != "" {
+			filterStrs = append(filterStrs, fmt.Sprintf("%s == '%s'", kbCollectionFieldFileType, p.FileType))
 		}
 
-		if contentType != "" {
-			filterStrs = append(filterStrs, fmt.Sprintf("%s == '%s'", kbCollectionFieldContentType, contentType))
+		if p.ContentType != "" {
+			filterStrs = append(filterStrs, fmt.Sprintf("%s == '%s'", kbCollectionFieldContentType, p.ContentType))
 		}
 	}
 
 	t = time.Now()
 	// Convert the input vector to float32
-	milvusVectors := make([]entity.Vector, len(vectors))
+	milvusVectors := make([]entity.Vector, len(p.Vectors))
 	// milvus search vector support batch search, but we just need one vector
-	for i, v := range vectors {
+	for i, v := range p.Vectors {
 		milvusVectors[i] = entity.FloatVector(v)
 	}
 	// Perform the search
@@ -356,6 +372,11 @@ func (m *milvusClient) SimilarVectorsInCollection(ctx context.Context, p service
 
 func (m *milvusClient) DropCollection(ctx context.Context, collectionName string) error {
 	return m.c.DropCollection(ctx, collectionName)
+}
+
+func (m *milvusClient) CheckFileUIDMetadata(ctx context.Context, collectionName string) (bool, error) {
+	_, hasFileUID, err := m.checkMetadataFields(ctx, collectionName)
+	return hasFileUID, err
 }
 
 // checkMetadataFields returns whether the collection schema has metadata

--- a/pkg/milvus/milvus_test.go
+++ b/pkg/milvus/milvus_test.go
@@ -1,0 +1,63 @@
+package milvus
+
+import (
+	"testing"
+
+	"github.com/gofrs/uuid"
+
+	qt "github.com/frankban/quicktest"
+)
+
+func TestFileUIDFilter(t *testing.T) {
+	c := qt.New(t)
+
+	// Create some test UUIDs
+	uid1 := uuid.FromStringOrNil("6e362976-bfc1-4677-b761-dcc12495b5bd")
+	uid2 := uuid.FromStringOrNil("f6f9f6ed-ab85-4753-9dbc-6dbd9a3818f3")
+	badUID := uuid.FromStringOrNil("nope")
+
+	testcases := []struct {
+		name     string
+		fileUIDs []uuid.UUID
+		want     string
+	}{
+		{
+			name:     "ok - single valid UUID",
+			fileUIDs: []uuid.UUID{uid1},
+			want:     `file_uid in ["6e362976-bfc1-4677-b761-dcc12495b5bd"]`,
+		},
+		{
+			name:     "ok - multiple valid UUIDs",
+			fileUIDs: []uuid.UUID{uid1, uid2},
+			want:     `file_uid in ["6e362976-bfc1-4677-b761-dcc12495b5bd","f6f9f6ed-ab85-4753-9dbc-6dbd9a3818f3"]`,
+		},
+		{
+			name:     "ok - empty slice",
+			fileUIDs: []uuid.UUID{},
+			want:     "",
+		},
+		{
+			name:     "ok - nil slice",
+			fileUIDs: nil,
+			want:     "",
+		},
+		{
+			name:     "ok - single nil UUID",
+			fileUIDs: []uuid.UUID{badUID},
+			want:     "",
+		},
+		{
+			name:     "ok - mixed valid and nil UUIDs",
+			fileUIDs: []uuid.UUID{uid1, badUID, uid2},
+			want:     `file_uid in ["6e362976-bfc1-4677-b761-dcc12495b5bd","f6f9f6ed-ab85-4753-9dbc-6dbd9a3818f3"]`,
+		},
+	}
+
+	for _, tc := range testcases {
+		c.Run(tc.name, func(c *qt.C) {
+			client := &milvusClient{}
+			got := client.fileUIDFilter(tc.fileUIDs)
+			c.Check(got, qt.Equals, tc.want)
+		})
+	}
+}

--- a/pkg/minio/knowledgebase.go
+++ b/pkg/minio/knowledgebase.go
@@ -19,8 +19,6 @@ type KnowledgeBaseI interface {
 	SaveConvertedFile(ctx context.Context, kbUID, convertedFileUID, fileExt string, content []byte) error
 	// SaveTextChunks saves batch of chunks(text files) to MinIO.
 	SaveTextChunks(ctx context.Context, kbUID string, chunks map[ChunkUIDType]ChunkContentType) error
-	// GetUploadedFilePathInKnowledgeBase returns the path of the uploaded file in MinIO.
-	GetUploadedFilePathInKnowledgeBase(kbUID, dest string) string
 	// GetConvertedFilePathInKnowledgeBase returns the path of the converted file in MinIO.
 	GetConvertedFilePathInKnowledgeBase(kbUID, ConvertedFileUID, fileExt string) string
 	// GetChunkPathInKnowledgeBase returns the path of the chunk in MinIO.
@@ -137,10 +135,6 @@ func (m *Minio) DeleteAllChunksInKb(ctx context.Context, kbUID string) chan erro
 	err := m.DeleteFilesWithPrefix(ctx, KnowledgeBaseBucketName, kbUID+chunkPrefix)
 
 	return err
-}
-
-func (m *Minio) GetUploadedFilePathInKnowledgeBase(kbUID, dest string) string {
-	return kbUID + uploadedFilePrefix + dest
 }
 
 func (m *Minio) GetConvertedFilePathInKnowledgeBase(kbUID, ConvertedFileUID, fileExt string) string {

--- a/pkg/service/object.go
+++ b/pkg/service/object.go
@@ -5,7 +5,6 @@ import (
 	"encoding/base64"
 	"errors"
 	"net/url"
-	"path"
 	"strconv"
 	"strings"
 	"time"
@@ -211,16 +210,6 @@ func (s *service) GetDownloadURL(
 		UrlExpireAt: timestamppb.New(expireAtTS),
 		Object:      objectInProto,
 	}, nil
-}
-
-// EncodedMinioURLPath get the encoded minio url path
-func EncodedMinioURLPath(namespaceID string, objectURLUUID uuid.UUID) string {
-
-	// Construct the path
-	urlPath := path.Join("v1alpha", "namespaces", namespaceID, "blob-urls", objectURLUUID.String())
-
-	// Ensure the path starts with a forward slash
-	return config.Config.Blob.HostPort + "/" + urlPath
 }
 
 // encodeBlobURL encodes the presigned URL to a blob URL. The presigned URL

--- a/pkg/service/retrieval.go
+++ b/pkg/service/retrieval.go
@@ -61,23 +61,6 @@ func (s *service) SimilarityChunksSearch(ctx context.Context, ownerUID uuid.UUID
 		fileUIDs = append(fileUIDs, uuid.FromStringOrNil(uid))
 	}
 
-	// The FileUid field is deprecated and used only when FileUids aren't
-	// present.
-	if len(fileUIDs) == 0 && req.GetFileUid() != "" {
-		fileUIDs = append(fileUIDs, uuid.FromStringOrNil(req.GetFileUid()))
-	}
-
-	// The FileName field is deprecated and used only in absence of the file UID
-	// params.
-	if len(fileUIDs) == 0 && req.GetFileName() != "" {
-		file, err := s.repository.GetKnowledgebaseFileByKbUIDAndFileID(ctx, kb.UID, req.GetFileName())
-		if err != nil {
-			return nil, fmt.Errorf("fetching kb file: %w", err)
-		}
-
-		fileUIDs = append(fileUIDs, file.UID)
-	}
-
 	topK := req.GetTopK()
 	if topK == 0 {
 		topK = 5

--- a/pkg/service/vector.go
+++ b/pkg/service/vector.go
@@ -32,7 +32,7 @@ type SimilarVectorSearchParam struct {
 	CollectionID string
 	Vectors      [][]float32
 	TopK         uint32
-	FileUID      uuid.UUID
+	FileUIDs     []uuid.UUID
 	FileType     string
 	ContentType  string
 
@@ -44,7 +44,7 @@ type SimilarVectorSearchParam struct {
 	// have a file UID in the schema. Some collections have rigid schemas
 	// without dynamic fields, so the original schema (with filename) couldn't
 	// be extended and backfilled to have a file UID.
-	FileName string
+	FileNames []string
 }
 
 // VectorDatabase implements the use necesasry cases to interact with a vector
@@ -55,6 +55,10 @@ type VectorDatabase interface {
 	DropCollection(_ context.Context, id string) error
 	SimilarVectorsInCollection(context.Context, SimilarVectorSearchParam) ([][]SimilarEmbedding, error)
 	DeleteEmbeddingsInCollection(_ context.Context, collID string, embeddingUID []string) error
+	// CheckFileUIDMetadata checks if the collection has the file UID metadata
+	// field, which wasn't introduced since the beginning and is not present in
+	// legacy collections.
+	CheckFileUIDMetadata(_ context.Context, collectionID string) (bool, error)
 }
 
 const kbCollectionPrefix = "kb_"

--- a/pkg/worker/persistentcatalogworker.go
+++ b/pkg/worker/persistentcatalogworker.go
@@ -331,6 +331,8 @@ func (wp *persistentCatalogFileToEmbWorkerPool) processFile(ctx context.Context,
 				return err
 			}
 			return nil
+		default:
+			return fmt.Errorf("unhandled status %s", status.String())
 		}
 	}
 }


### PR DESCRIPTION
Because

- We want to filter similar chunks by more than one file UID

This commit

- Indexes embeddings by file UID
- Takes a file UID list as a parameter in similarity search (and question
  answering)
- Removes the file UID and filename params in the similarity search
  endpoint.
