### PR TITLE
fix(kbfile): use filename in object when uploading a new file by reference

### DIFF
--- a/pkg/handler/knowledgebasefiles.go
+++ b/pkg/handler/knowledgebasefiles.go
@@ -210,12 +210,13 @@ func (ph *PublicHandler) UploadCatalogFile(ctx context.Context, req *artifactpb.
 		// 		humanReadable, tier.String(), errorsx.ErrInvalidArgument)
 		// }
 
-		req.File.Type = determineFileType(object.Name)
-
-		kbFile.Type = req.File.Type.String()
+		kbFile.Name = object.Name
 		kbFile.CreatorUID = object.CreatorUID
 		kbFile.Destination = object.Destination
 		kbFile.Size = object.Size
+
+		req.File.Type = determineFileType(object.Name)
+		kbFile.Type = req.File.Type.String()
 	}
 
 	// create catalog file in database


### PR DESCRIPTION
Because

- When refactoring the upload logic, the filename property wasn't
  properly ported when the file is an existing object.

This commit

- Reads the filename from the object record
