### PR TITLE
feat(chunk): return page-level citation context in file list and similar chunk search

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/google/go-cmp v0.7.0
 	github.com/grpc-ecosystem/go-grpc-middleware v1.4.0
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.1
-	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20250901141247-a88b66c21745
+	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20250910144745-40a99f482d4b
 	github.com/instill-ai/usage-client v0.4.0
 	github.com/instill-ai/x v0.10.0-alpha
 	github.com/knadh/koanf v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -269,8 +269,8 @@ github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpO
 github.com/hydrogen18/memlistener v0.0.0-20200120041712-dcc25e7acd91/go.mod h1:qEIFzExnS6016fRpRfxrExeVn2gbClQA99gQhnIcdhE=
 github.com/imkira/go-interpol v1.1.0/go.mod h1:z0h2/2T3XF8kyEPpRgJ3kmNv+C43p+I/CoI+jC3w2iA=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20250901141247-a88b66c21745 h1:dgDUy1D79waysAPNWd/sHAIG5QCkqC4myszNaZBJIsI=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20250901141247-a88b66c21745/go.mod h1:bCnBosofpaUxKBuTTJM3/I3thAK37kvfBnKByjnLsl4=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20250910144745-40a99f482d4b h1:N09H+4itA8AeNvstkqRP925zAGNirsr+qfaySooEJ8Q=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20250910144745-40a99f482d4b/go.mod h1:bCnBosofpaUxKBuTTJM3/I3thAK37kvfBnKByjnLsl4=
 github.com/instill-ai/usage-client v0.4.0 h1:xf1hAlO4a8lZwZzz9bprZOJqU3ghIcIsavUUB7UURyg=
 github.com/instill-ai/usage-client v0.4.0/go.mod h1:zZ9LRoXps2u63ARYPAbR2YvqTib3dWJLObZn+9YqhF0=
 github.com/instill-ai/x v0.10.0-alpha h1:I83WJc+21J+IgI4aJDn755ON/BX4cDvKCVVguI77r14=

--- a/pkg/handler/knowledgebasefiles.go
+++ b/pkg/handler/knowledgebasefiles.go
@@ -523,7 +523,7 @@ func (ph *PublicHandler) ListCatalogFiles(ctx context.Context, req *artifactpb.L
 			downloadURL = response.GetDownloadUrl()
 		}
 
-		files = append(files, &artifactpb.File{
+		file := &artifactpb.File{
 			FileUid:            kbFile.UID.String(),
 			OwnerUid:           kbFile.Owner.String(),
 			CreatorUid:         kbFile.CreatorUID.String(),
@@ -541,7 +541,21 @@ func (ph *PublicHandler) ListCatalogFiles(ctx context.Context, req *artifactpb.L
 			Summary:            string(kbFile.Summary),
 			DownloadUrl:        downloadURL,
 			ConvertingPipeline: kbFile.ConvertingPipeline(),
-		})
+		}
+
+		// TODO: the converting step will extract the page length from the
+		// original file. We'll temporarily return static data so the frontend
+		// can use it to develop the file preview.
+		if file.ProcessStatus > artifactpb.FileProcessStatus_FILE_PROCESS_STATUS_CONVERTING &&
+			file.Type == artifactpb.FileType_FILE_TYPE_PDF {
+
+			file.Length = &artifactpb.File_Position{
+				Unit:        artifactpb.File_Position_UNIT_PAGE,
+				Coordinates: []uint32{4},
+			}
+		}
+
+		files = append(files, file)
 	}
 
 	return &artifactpb.ListCatalogFilesResponse{


### PR DESCRIPTION
This commit

- Returns static data for the page lenght of PDF documents and the chunk
  position for its extracted chunks. PDFs will have 4 pages and chunks
  will be in page 2.
