### PR TITLE
feat(kbfile): return length in conversion step and store it as metadata

### DIFF
--- a/pkg/handler/knowledgebasefiles.go
+++ b/pkg/handler/knowledgebasefiles.go
@@ -543,15 +543,13 @@ func (ph *PublicHandler) ListCatalogFiles(ctx context.Context, req *artifactpb.L
 			ConvertingPipeline: kbFile.ConvertingPipeline(),
 		}
 
-		// TODO: the converting step will extract the page length from the
-		// original file. We'll temporarily return static data so the frontend
-		// can use it to develop the file preview.
-		if file.ProcessStatus > artifactpb.FileProcessStatus_FILE_PROCESS_STATUS_CONVERTING &&
-			file.Type == artifactpb.FileType_FILE_TYPE_PDF {
-
+		if kbFile.ExtraMetaDataUnmarshal != nil && kbFile.ExtraMetaDataUnmarshal.Length != nil {
 			file.Length = &artifactpb.File_Position{
+				// For now, only document conversion extracts page length, so
+				// we know the unit. When more types are supported, we'll need
+				// a service method that maps the file type to the length unit.
 				Unit:        artifactpb.File_Position_UNIT_PAGE,
-				Coordinates: []uint32{4},
+				Coordinates: kbFile.ExtraMetaDataUnmarshal.Length,
 			}
 		}
 

--- a/pkg/repository/knowledgebasefile.go
+++ b/pkg/repository/knowledgebasefile.go
@@ -110,6 +110,10 @@ type ExtraMetaData struct {
 	SummarizingTime int64  `json:"summarizing_time"`
 	ChunkingTime    int64  `json:"chunking_time"`
 	EmbeddingTime   int64  `json:"embedding_time"`
+
+	// Length of the file. The unit will depend on the filetype (e.g. pages,
+	// milliseconds).
+	Length []uint32 `json:"length,omitempty"`
 }
 
 // table columns map
@@ -786,6 +790,9 @@ func (r *Repository) UpdateKBFileMetadata(ctx context.Context, fileUID uuid.UUID
 		}
 		if updates.EmbeddingTime != 0 {
 			file.ExtraMetaDataUnmarshal.EmbeddingTime = updates.EmbeddingTime
+		}
+		if len(updates.Length) > 0 {
+			file.ExtraMetaDataUnmarshal.Length = updates.Length
 		}
 
 		// Marshal the updated ExtraMetaData.

--- a/pkg/service/conversion.go
+++ b/pkg/service/conversion.go
@@ -1,0 +1,167 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"go.uber.org/zap"
+	"google.golang.org/protobuf/types/known/structpb"
+
+	artifactpb "github.com/instill-ai/protogen-go/artifact/artifact/v1alpha"
+	pipelinepb "github.com/instill-ai/protogen-go/pipeline/pipeline/v1beta"
+	logx "github.com/instill-ai/x/log"
+)
+
+// MDConversionParams contains the information required to convert a file to
+// markdown.
+type MDConversionParams struct {
+	Base64Content string
+	Type          artifactpb.FileType
+	Pipelines     []PipelineRelease
+}
+
+// MDConversionResult contains the information extracted from the conversion
+// step.
+type MDConversionResult struct {
+	Markdown     string
+	PositionData *PositionData
+
+	// Length of the file. The unit and dimensions will depend on the filetype
+	// (e.g. pages, milliseconds, pixels).
+	Length []uint32
+
+	// PipelineRelease is the pipeline used for conversion.
+	PipelineRelease PipelineRelease
+}
+
+// PositionData contains metadata from the conversion step that will be used to
+// position the chunks extracted from the Markdown string within the original
+// file.
+//
+// When more filetypes are supported, this entity might evolve to accommodate
+// other kinds of positions (e.g. time markers mapping a character to a
+// duration).
+type PositionData struct {
+	// Page delimiters contains the position of the last character in each
+	// page.
+	PageDelimiters []int32
+}
+
+// convertResultParser extracts the conversion result from the pipeline
+// response. It first checks for a non-empty "convert_result" field, then falls
+// back to "convert_result2". Returns an error if neither field contains valid
+// data or if the response structure is invalid.
+func convertResultParser(resp *pipelinepb.TriggerNamespacePipelineReleaseResponse) (string, error) {
+	if resp == nil || len(resp.Outputs) == 0 {
+		return "", fmt.Errorf("response is nil or has no outputs. resp: %v", resp)
+	}
+	fields := resp.Outputs[0].GetFields()
+	if fields == nil {
+		return "", fmt.Errorf("fields in the output are nil. resp: %v", resp)
+	}
+
+	convertResult, ok := fields["convert_result"]
+	if ok && convertResult.GetStringValue() != "" {
+		return convertResult.GetStringValue(), nil
+	}
+	convertResult2, ok2 := fields["convert_result2"]
+	if ok2 && convertResult2.GetStringValue() != "" {
+		return convertResult2.GetStringValue(), nil
+	}
+
+	return "", nil
+}
+
+// ConvertToMDPipe converts a file into Markdown by triggering a converting
+// pipeline. If conversion succeeds, the catalog file record will be updated
+// with the pipeline used to produce the results.
+//   - If the file has a document type extension (pdf, doc[x], ppt[x]) the client
+//     may specify a slice of pipelines, which will be triggered in order until a
+//     successful trigger produces a non-empty result.
+//   - If no pipelines are specified, ConvertDocToMDPipeline will be used by
+//     default.
+//   - Non-document files will use ConvertDocToMDStandardPipeline, as these types
+//     tend to be trivial to convert and can use a deterministic pipeline instead
+//     of a custom one that improves the conversion performance.
+func (s *service) ConvertToMDPipe(ctx context.Context, p MDConversionParams) (*MDConversionResult, error) {
+	ctx, cancel := context.WithTimeout(ctx, 300*time.Second)
+	defer cancel()
+
+	logger, _ := logx.GetZapLogger(ctx)
+
+	// Get the appropriate prefix for the file type
+	prefix := GetFileTypePrefix(p.Type)
+
+	input := &structpb.Struct{
+		Fields: map[string]*structpb.Value{
+			"document_input": structpb.NewStringValue(prefix + p.Base64Content),
+		},
+	}
+
+	// Determine which pipeline and version to use based on file type
+	switch p.Type {
+	// Spreadsheet types and others use the original pipeline
+	case artifactpb.FileType_FILE_TYPE_XLSX,
+		artifactpb.FileType_FILE_TYPE_XLS,
+		artifactpb.FileType_FILE_TYPE_CSV,
+		artifactpb.FileType_FILE_TYPE_HTML:
+
+		p.Pipelines = []PipelineRelease{ConvertDocToMDStandardPipeline}
+
+	// Document types use the conversion pipeline configured in the catalog, if
+	// present, or the default one for documents (parsing-router if the request
+	// comes from Instill Agent, the advanced conversion pipeline otherwise).
+	case artifactpb.FileType_FILE_TYPE_PDF,
+		artifactpb.FileType_FILE_TYPE_DOCX,
+		artifactpb.FileType_FILE_TYPE_DOC,
+		artifactpb.FileType_FILE_TYPE_PPT,
+		artifactpb.FileType_FILE_TYPE_PPTX:
+
+		if len(p.Pipelines) != 0 {
+			break
+		}
+
+		p.Pipelines = DefaultConversionPipelines
+
+	default:
+		return nil, fmt.Errorf("unsupported file type: %v", p.Type)
+	}
+
+	for _, pipeline := range p.Pipelines {
+		req := &pipelinepb.TriggerNamespacePipelineReleaseRequest{
+			NamespaceId: pipeline.Namespace,
+			PipelineId:  pipeline.ID,
+			ReleaseId:   pipeline.Version,
+			Inputs:      []*structpb.Struct{input},
+		}
+
+		resp, err := s.pipelinePub.TriggerNamespacePipelineRelease(ctx, req)
+		if err != nil {
+			return nil, fmt.Errorf("triggering %s pipeline: %w", pipeline.ID, err)
+		}
+
+		md, err := convertResultParser(resp)
+		if err != nil {
+			return nil, fmt.Errorf("getting conversion result: %w", err)
+		}
+
+		if md == "" {
+			logger.Info("Conversion pipeline didn't yield results", zap.String("pipeline", pipeline.Name()))
+			continue
+		}
+
+		return &MDConversionResult{
+			Markdown:        md,
+			PipelineRelease: pipeline,
+
+			// TODO jvallesm: read the length and position data from the
+			// pipeline results. First we'll update the conversion method
+			// interface and implement the changes in the clients. After
+			// verifying these are backwards-compatible, we'll implement the
+			// length and position extraction.
+		}, nil
+	}
+
+	return nil, fmt.Errorf("conversion pipelines didn't produce any result")
+}

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -19,7 +19,7 @@ import (
 // Service defines the Artifact domain use cases.
 type Service interface {
 	CheckNamespacePermission(context.Context, *resource.Namespace) error
-	ConvertToMDPipe(_ context.Context, fileUID uuid.UUID, fileBase64 string, _ artifactpb.FileType, _ []PipelineRelease) (string, error)
+	ConvertToMDPipe(context.Context, MDConversionParams) (*MDConversionResult, error)
 	GenerateSummary(_ context.Context, content, fileType string) (string, error)
 	ChunkMarkdownPipe(_ context.Context, markdown string) ([]Chunk, error)
 	ChunkTextPipe(_ context.Context, text string) ([]Chunk, error)


### PR DESCRIPTION
This commit

- Modifies the signature of the conversion method to delegate on the
  client (worker) the storage of the conversion pipeline and length.
- Reads the file length from the database.
