### PR TITLE
fix(integration-test): fix file summary check 

### DIFF
--- a/integration-test/rest-public.js
+++ b/integration-test/rest-public.js
@@ -331,14 +331,14 @@ export function CheckCatalog(data) {
       }
       check(viewRes, {
         [`GET ${viewPath} 200 (${f.name}: ${f.type})`]: (r) => r.status === 200,
-        [`GET ${viewPath} file has name (${f.name}: ${f.type})`]: (r) =>  r.json().files[0].name === f.name,
-        [`GET ${viewPath} file process status is COMPLETED (${f.name}: ${f.type})`]: (r) =>  r.json().files[0].processStatus === "FILE_PROCESS_STATUS_COMPLETED",
-        [`GET ${viewPath} file has creatorUid (${f.name}: ${f.type})`]: (r) =>  r.json().files[0].creatorUid === data.expectedOwner.uid,
-        [`GET ${viewPath} file has size (${f.name}: ${f.type})`]: (r) =>  r.json().files[0].size > 0,
-        [`GET ${viewPath} file has totalChunks (${f.name}: ${f.type})`]: (r) =>  r.json().files[0].totalChunks > 0,
-        [`GET ${viewPath} file has totalTokens (${f.name}: ${f.type})`]: (r) =>  r.json().files[0].totalTokens > 0,
-        [`GET ${viewPath} file has summary (${f.name}: ${f.type})`]: (r) =>  r.json().files[0].summary > 0,
-        [`GET ${viewPath} file has downloadUrl (${f.name}: ${f.type})`]: (r) =>  r.json().files[0].downloadUrl.includes("v1alpha/blob-urls/"),
+        [`GET ${viewPath} file has name (${f.name}: ${f.type})`]: (r) => r.json().files[0].name === f.name,
+        [`GET ${viewPath} file process status is COMPLETED (${f.name}: ${f.type})`]: (r) => r.json().files[0].processStatus === "FILE_PROCESS_STATUS_COMPLETED",
+        [`GET ${viewPath} file has creatorUid (${f.name}: ${f.type})`]: (r) => r.json().files[0].creatorUid === data.expectedOwner.uid,
+        [`GET ${viewPath} file has size (${f.name}: ${f.type})`]: (r) => r.json().files[0].size > 0,
+        [`GET ${viewPath} file has totalChunks (${f.name}: ${f.type})`]: (r) => r.json().files[0].totalChunks > 0,
+        [`GET ${viewPath} file has totalTokens (${f.name}: ${f.type})`]: (r) => r.json().files[0].totalTokens > 0,
+        [`GET ${viewPath} file has summary (${f.name}: ${f.type})`]: (r) => r.json().files[0].summary.length > 0,
+        [`GET ${viewPath} file has downloadUrl (${f.name}: ${f.type})`]: (r) => r.json().files[0].downloadUrl.includes("v1alpha/blob-urls/"),
       });
     }
 


### PR DESCRIPTION
This commit

- Checks the summary field is not empty instead of being > 0 in the
  processed file integration tests.