### PR TITLE
feat(conversion): extract pages in conversion step

### DIFF
--- a/integration-test/proto/artifact/artifact/v1alpha/artifact.proto
+++ b/integration-test/proto/artifact/artifact/v1alpha/artifact.proto
@@ -415,6 +415,31 @@ enum FileType {
 
 // file
 message File {
+  // Position within a file, as coordinates in a a specific unit. The
+  // number of dimensions of the coordinate depends on the unit type.
+  message Position {
+    // Unit of measurement for a position within a file.
+    enum Unit {
+      // Unspecified.
+      UNIT_UNSPECIFIED = 0;
+      // Character positions (for Markdown and other text files).
+      UNIT_CHARACTER = 1;
+      // Page positions (for documents). For pages, positions are 1-indexed
+      // (e.g., page 4 of 4) to align with document visualization standards.
+      UNIT_PAGE = 2;
+      // Time positions in milliseconds (for audio/video files).
+      UNIT_TIME_MS = 3;
+      // Pixel positions (for images and other 2D content).
+      UNIT_PIXEL = 4;
+    }
+
+    // Unit of measurement for the position.
+    Unit unit = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+
+    // Position value.
+    repeated uint32 coordinates = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
+  }
+
   // file uid
   string file_uid = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
   // file name
@@ -484,6 +509,10 @@ message File {
   // (such files are typically trivial to convert and don't require a dedicated
   // pipeline to improve the conversion performance).
   optional string converting_pipeline = 21;
+  // Length of the file in the specified unit type. It is defined as the number
+  // of positions (the unit will depend on the file type) that can be accessed
+  // in the file.
+  Position length = 22 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // upload file request
@@ -526,11 +555,13 @@ message ProcessCatalogFilesResponse {
   repeated File files = 1;
 }
 
-// list file filter
-// todo: support more parameters
+// ListCatalogFilesFilter contains a set of properties to filter a catalog file
+// list by.
 message ListCatalogFilesFilter {
-  // The file uids.
-  repeated string file_uids = 2 [(google.api.field_behavior) = OPTIONAL];
+  // File UIDs.
+  repeated string file_uids = 1 [(google.api.field_behavior) = OPTIONAL];
+  // Processing status of the files.
+  FileProcessStatus process_status = 2 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // list files request

--- a/integration-test/proto/artifact/artifact/v1alpha/artifact_public_service.proto
+++ b/integration-test/proto/artifact/artifact/v1alpha/artifact_public_service.proto
@@ -380,7 +380,6 @@ service ArtifactPublicService {
   //
   // Returns the upload URL of an object.
   rpc GetObjectUploadURL(GetObjectUploadURLRequest) returns (GetObjectUploadURLResponse) {
-    option deprecated = true;
     option (google.api.http) = {get: "/v1alpha/namespaces/{namespace_id}/object-upload-url"};
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       tags: "Artifact"
@@ -395,7 +394,6 @@ service ArtifactPublicService {
   //
   // Returns the download URL of an object.
   rpc GetObjectDownloadURL(GetObjectDownloadURLRequest) returns (GetObjectDownloadURLResponse) {
-    option deprecated = true;
     option (google.api.http) = {get: "/v1alpha/namespaces/{namespace_id}/object-download-url"};
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       tags: "Artifact"

--- a/integration-test/proto/artifact/artifact/v1alpha/chunk.proto
+++ b/integration-test/proto/artifact/artifact/v1alpha/chunk.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 
 package artifact.artifact.v1alpha;
 
+import "artifact/artifact/v1alpha/artifact.proto";
 // Protocol Buffers Well-Known Types
 import "google/api/field_behavior.proto";
 import "google/protobuf/timestamp.proto";
@@ -34,14 +35,18 @@ enum ContentType {
 
 // The Chunk message represents a chunk of data in the artifact system.
 message Chunk {
+  // Reference represents the position of a chunk within a file.
+  message Reference {
+    // Start position of the chunk within the file.
+    File.Position start = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+    // End position of the chunk within the file.
+    File.Position end = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
+  }
+
   // unique identifier of the chunk
   string chunk_uid = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
   // whether the chunk is retrievable
   bool retrievable = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // start position of the chunk in the source file
-  uint32 start_pos = 4 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // end position of the chunk in the source file
-  uint32 end_pos = 5 [(google.api.field_behavior) = OUTPUT_ONLY];
   // tokens of the chunk
   uint32 tokens = 6 [(google.api.field_behavior) = OUTPUT_ONLY];
   // creation time of the chunk
@@ -50,6 +55,23 @@ message Chunk {
   string original_file_uid = 8 [(google.api.field_behavior) = OUTPUT_ONLY];
   // content type
   ContentType content_type = 9 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Reference to the position of the chunk within the original file.
+  Reference reference = 10 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Reference to the position of the chunk within the Markdown (source) file.
+  Reference markdown_reference = 11 [(google.api.field_behavior) = OUTPUT_ONLY];
+
+  // start position of the chunk in the source file
+  // Deprecated: use markdown_reference instead
+  uint32 start_pos = 4 [
+    deprecated = true,
+    (google.api.field_behavior) = OUTPUT_ONLY
+  ];
+  // end position of the chunk in the source file
+  // Deprecated: use markdown_reference instead
+  uint32 end_pos = 5 [
+    deprecated = true,
+    (google.api.field_behavior) = OUTPUT_ONLY
+  ];
 }
 
 // The ListChunksRequest message represents a request to list chunks in the artifact system.

--- a/integration-test/proto/artifact/artifact/v1alpha/object.proto
+++ b/integration-test/proto/artifact/artifact/v1alpha/object.proto
@@ -9,7 +9,6 @@ import "google/protobuf/timestamp.proto";
 
 // Object
 message Object {
-  option deprecated = true;
   // uid
   string uid = 1;
   // name of the object
@@ -40,7 +39,6 @@ message Object {
 
 // GetObjectUploadURLRequest
 message GetObjectUploadURLRequest {
-  option deprecated = true;
   // id of the namespace
   string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
   // name of the object with length limit to 1024 characters.
@@ -59,7 +57,6 @@ message GetObjectUploadURLRequest {
 
 // GetObjectUploadURLResponse
 message GetObjectUploadURLResponse {
-  option deprecated = true;
   // upload url
   string upload_url = 1;
   // expire at in UTC (UTC+0)
@@ -70,7 +67,6 @@ message GetObjectUploadURLResponse {
 
 // GetObjectDownloadURLRequest
 message GetObjectDownloadURLRequest {
-  option deprecated = true;
   // id of the namespace
   string namespace_id = 1 [(google.api.field_behavior) = REQUIRED];
   // uid of the object
@@ -82,7 +78,6 @@ message GetObjectDownloadURLRequest {
 
 // GetObjectDownloadURLResponse
 message GetObjectDownloadURLResponse {
-  option deprecated = true;
   // download url
   string download_url = 1;
   // expire at in UTC (UTC+0)

--- a/integration-test/rest-public.js
+++ b/integration-test/rest-public.js
@@ -340,6 +340,19 @@ export function CheckCatalog(data) {
         [`GET ${viewPath} file has summary (${f.name}: ${f.type})`]: (r) => r.json().files[0].summary.length > 0,
         [`GET ${viewPath} file has downloadUrl (${f.name}: ${f.type})`]: (r) => r.json().files[0].downloadUrl.includes("v1alpha/blob-urls/"),
       });
+
+      // Check conversion pipeline and page information depending on the file type
+      const isDocumentType = ["FILE_TYPE_PDF", "FILE_TYPE_DOC", "FILE_TYPE_DOCX", "FILE_TYPE_PPT", "FILE_TYPE_PPTX"].includes(f.type);
+
+      if (isDocumentType) {
+        // For document types, check that length unit is pages and coordinates contain page count
+        const fileData = viewRes.json().files[0];
+        check(viewRes, {
+          [`GET ${viewPath} file has length unit UNIT_PAGE (${f.name}: ${f.type})`]: () => fileData.length && fileData.length.unit === "UNIT_PAGE",
+          [`GET ${viewPath} file has length coordinates (${f.name}: ${f.type})`]: () => fileData.length && Array.isArray(fileData.length.coordinates) && fileData.length.coordinates.length > 0,
+          [`GET ${viewPath} file length coordinates is positive (${f.name}: ${f.type})`]: () => fileData.length && fileData.length.coordinates[0] > 0,
+        });
+      }
     }
 
     // List catalog files

--- a/pkg/service/conversion.go
+++ b/pkg/service/conversion.go
@@ -40,27 +40,53 @@ type MDConversionResult struct {
 
 // convertResultParser extracts the conversion result from the pipeline
 // response. It first checks for a non-empty "convert_result" field, then falls
-// back to "convert_result2". Returns an error if neither field contains valid
-// data or if the response structure is invalid.
-func convertResultParser(resp *pipelinepb.TriggerNamespacePipelineReleaseResponse) (string, error) {
+// back to "convert_result2". It handles both single strings (for non-page-based
+// files) and arrays of strings (for page-based files). Returns an error if
+// neither field contains valid data or if the response structure is invalid.
+func convertResultParser(resp *pipelinepb.TriggerNamespacePipelineReleaseResponse) (*MDConversionResult, error) {
 	if resp == nil || len(resp.Outputs) == 0 {
-		return "", fmt.Errorf("response is nil or has no outputs. resp: %v", resp)
+		return nil, fmt.Errorf("response is nil or has no outputs. resp: %v", resp)
 	}
 	fields := resp.Outputs[0].GetFields()
 	if fields == nil {
-		return "", fmt.Errorf("fields in the output are nil. resp: %v", resp)
+		return nil, fmt.Errorf("fields in the output are nil. resp: %v", resp)
 	}
 
+	// Try convert_result first, then convert_result2 as fallback
+	suffix := "\n"
 	convertResult, ok := fields["convert_result"]
-	if ok && convertResult.GetStringValue() != "" {
-		return convertResult.GetStringValue(), nil
-	}
-	convertResult2, ok2 := fields["convert_result2"]
-	if ok2 && convertResult2.GetStringValue() != "" {
-		return convertResult2.GetStringValue(), nil
+	if !ok {
+		convertResult, ok = fields["convert_result2"]
+		if !ok {
+			return nil, fmt.Errorf("no conversion result fields found in response")
+		}
+
+		suffix = ""
 	}
 
-	return "", nil
+	// Check if it's a list (page-based files)
+	if list := convertResult.GetListValue(); list != nil {
+		pages := ProtoListToStrings(list, suffix)
+		if len(pages) == 0 {
+			return nil, fmt.Errorf("empty page list in conversion result")
+		}
+
+		return &MDConversionResult{
+			Markdown:     strings.Join(pages, ""),
+			Length:       []uint32{uint32(len(pages))},
+			PositionData: PositionDataFromPages(pages),
+		}, nil
+	}
+
+	// Check if it's a string (non-page-based files)
+	md := convertResult.GetStringValue()
+	if md == "" {
+		return nil, fmt.Errorf("empty markdown string in conversion result")
+	}
+	return &MDConversionResult{
+		Markdown: md,
+		// No length or position data for non-page-based files
+	}, nil
 }
 
 // ConvertToMDPipe converts a file into Markdown by triggering a converting
@@ -108,12 +134,17 @@ func (s *service) ConvertToMDPipe(ctx context.Context, p MDConversionParams) (*M
 		artifactpb.FileType_FILE_TYPE_PPT,
 		artifactpb.FileType_FILE_TYPE_PPTX:
 
-		if len(p.Pipelines) != 0 {
-			break
+		// If this is a reprocessing scenario with the default pipeline (same
+		// namespace and ID, but potentially different version), reprocess with
+		// the newest version of the default pipeline
+		reprocessWithDefaultPipeline := len(p.Pipelines) == 1 &&
+			p.Pipelines[0].Namespace == ConvertDocToMDPipeline.Namespace &&
+			p.Pipelines[0].ID == ConvertDocToMDPipeline.ID
+
+		//
+		if len(p.Pipelines) == 0 || reprocessWithDefaultPipeline {
+			p.Pipelines = DefaultConversionPipelines
 		}
-
-		p.Pipelines = DefaultConversionPipelines
-
 	default:
 		return nil, fmt.Errorf("unsupported file type: %v", p.Type)
 	}
@@ -131,26 +162,19 @@ func (s *service) ConvertToMDPipe(ctx context.Context, p MDConversionParams) (*M
 			return nil, fmt.Errorf("triggering %s pipeline: %w", pipeline.ID, err)
 		}
 
-		md, err := convertResultParser(resp)
+		result, err := convertResultParser(resp)
 		if err != nil {
 			return nil, fmt.Errorf("getting conversion result: %w", err)
 		}
 
-		if md == "" {
+		if result == nil || result.Markdown == "" {
 			logger.Info("Conversion pipeline didn't yield results", zap.String("pipeline", pipeline.Name()))
 			continue
 		}
 
-		return &MDConversionResult{
-			Markdown:        md,
-			PipelineRelease: pipeline,
-
-			// TODO jvallesm: read the length and position data from the
-			// pipeline results. First we'll update the conversion method
-			// interface and implement the changes in the clients. After
-			// verifying these are backwards-compatible, we'll implement the
-			// length and position extraction.
-		}, nil
+		// Set the pipeline release used for this conversion
+		result.PipelineRelease = pipeline
+		return result, nil
 	}
 
 	return nil, fmt.Errorf("conversion pipelines didn't produce any result")

--- a/pkg/service/conversion_test.go
+++ b/pkg/service/conversion_test.go
@@ -1,0 +1,169 @@
+package service
+
+import (
+	"testing"
+
+	"google.golang.org/protobuf/types/known/structpb"
+
+	"github.com/instill-ai/artifact-backend/pkg/repository"
+
+	qt "github.com/frankban/quicktest"
+)
+
+func TestProtoListToStrings(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name     string
+		list     *structpb.ListValue
+		suffix   string
+		expected []string
+	}{
+		{
+			name:     "empty list",
+			list:     &structpb.ListValue{Values: []*structpb.Value{}},
+			suffix:   "",
+			expected: []string{},
+		},
+		{
+			name: "single string",
+			list: &structpb.ListValue{
+				Values: []*structpb.Value{
+					structpb.NewStringValue("hello"),
+				},
+			},
+			suffix:   "",
+			expected: []string{"hello"},
+		},
+		{
+			name: "multiple strings without suffix",
+			list: &structpb.ListValue{
+				Values: []*structpb.Value{
+					structpb.NewStringValue("hello"),
+					structpb.NewStringValue("world"),
+					structpb.NewStringValue("test"),
+				},
+			},
+			suffix:   "",
+			expected: []string{"hello", "world", "test"},
+		},
+		{
+			name: "multiple strings with suffix",
+			list: &structpb.ListValue{
+				Values: []*structpb.Value{
+					structpb.NewStringValue("hello"),
+					structpb.NewStringValue("world"),
+					structpb.NewStringValue("test"),
+				},
+			},
+			suffix:   "\n",
+			expected: []string{"hello\n", "world\n", "test"},
+		},
+		{
+			name: "strings with existing suffix",
+			list: &structpb.ListValue{
+				Values: []*structpb.Value{
+					structpb.NewStringValue("hello\n"),
+					structpb.NewStringValue("world\n"),
+					structpb.NewStringValue("test"),
+				},
+			},
+			suffix:   "\n",
+			expected: []string{"hello\n", "world\n", "test"},
+		},
+		{
+			name: "empty strings filtered out",
+			list: &structpb.ListValue{
+				Values: []*structpb.Value{
+					structpb.NewStringValue("hello"),
+					structpb.NewStringValue(""),
+					structpb.NewStringValue("world"),
+					structpb.NewStringValue(""),
+					structpb.NewStringValue("test"),
+				},
+			},
+			suffix:   "",
+			expected: []string{"hello", "world", "test"},
+		},
+		{
+			name:     "nil list",
+			list:     nil,
+			suffix:   "",
+			expected: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		c.Run(tt.name, func(c *qt.C) {
+			result := ProtoListToStrings(tt.list, tt.suffix)
+			c.Assert(result, qt.DeepEquals, tt.expected)
+		})
+	}
+}
+
+func TestPositionDataFromPages(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name     string
+		pages    []string
+		expected *repository.PositionData
+	}{
+		{
+			name:     "empty pages",
+			pages:    []string{},
+			expected: nil,
+		},
+		{
+			name:     "nil pages",
+			pages:    nil,
+			expected: nil,
+		},
+		{
+			name:  "single page",
+			pages: []string{"hello world"},
+			expected: &repository.PositionData{
+				PageDelimiters: []uint32{11}, // "hello world" has 11 characters
+			},
+		},
+		{
+			name:  "multiple pages",
+			pages: []string{"hello", "world", "test"},
+			expected: &repository.PositionData{
+				PageDelimiters: []uint32{5, 10, 14}, // cumulative: 5, 5+5, 5+5+4
+			},
+		},
+		{
+			name:  "pages with unicode characters",
+			pages: []string{"héllo", "wörld", "tëst"},
+			expected: &repository.PositionData{
+				PageDelimiters: []uint32{5, 10, 14}, // unicode characters count as 1 rune each
+			},
+		},
+		{
+			name:  "empty pages filtered",
+			pages: []string{"hello", "", "world", "", "test"},
+			expected: &repository.PositionData{
+				PageDelimiters: []uint32{5, 5, 10, 10, 14}, // empty strings still count as pages
+			},
+		},
+		{
+			name:  "pages with newlines",
+			pages: []string{"hello\nworld", "test\ncase"},
+			expected: &repository.PositionData{
+				PageDelimiters: []uint32{11, 20}, // "hello\nworld" = 11 chars, "test\ncase" = 9 chars
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		c.Run(tt.name, func(c *qt.C) {
+			result := PositionDataFromPages(tt.pages)
+			if tt.expected == nil {
+				c.Assert(result, qt.IsNil)
+			} else {
+				c.Assert(result, qt.DeepEquals, tt.expected)
+			}
+		})
+	}
+}

--- a/pkg/service/conversion_test.go
+++ b/pkg/service/conversion_test.go
@@ -5,165 +5,110 @@ import (
 
 	"google.golang.org/protobuf/types/known/structpb"
 
+	qt "github.com/frankban/quicktest"
+
 	"github.com/instill-ai/artifact-backend/pkg/repository"
 
-	qt "github.com/frankban/quicktest"
+	pipelinepb "github.com/instill-ai/protogen-go/pipeline/pipeline/v1beta"
 )
 
-func TestProtoListToStrings(t *testing.T) {
+func TestConvertResultParser(t *testing.T) {
 	c := qt.New(t)
 
 	tests := []struct {
 		name     string
-		list     *structpb.ListValue
-		suffix   string
-		expected []string
+		response *structpb.Struct
+		expected *MDConversionResult
+		wantErr  string
 	}{
 		{
-			name:     "empty list",
-			list:     &structpb.ListValue{Values: []*structpb.Value{}},
-			suffix:   "",
-			expected: []string{},
-		},
-		{
-			name: "single string",
-			list: &structpb.ListValue{
-				Values: []*structpb.Value{
-					structpb.NewStringValue("hello"),
+			name: "single string result",
+			response: &structpb.Struct{
+				Fields: map[string]*structpb.Value{
+					"convert_result": structpb.NewStringValue("Hello world"),
 				},
 			},
-			suffix:   "",
-			expected: []string{"hello"},
+			expected: &MDConversionResult{
+				Markdown: "Hello world",
+			},
 		},
 		{
-			name: "multiple strings without suffix",
-			list: &structpb.ListValue{
-				Values: []*structpb.Value{
-					structpb.NewStringValue("hello"),
-					structpb.NewStringValue("world"),
-					structpb.NewStringValue("test"),
+			name: "array of strings result",
+			response: &structpb.Struct{
+				Fields: map[string]*structpb.Value{
+					"convert_result": structpb.NewListValue(&structpb.ListValue{
+						Values: []*structpb.Value{
+							structpb.NewStringValue("Page 1"),
+							structpb.NewStringValue("Page 2"),
+						},
+					}),
 				},
 			},
-			suffix:   "",
-			expected: []string{"hello", "world", "test"},
-		},
-		{
-			name: "multiple strings with suffix",
-			list: &structpb.ListValue{
-				Values: []*structpb.Value{
-					structpb.NewStringValue("hello"),
-					structpb.NewStringValue("world"),
-					structpb.NewStringValue("test"),
+			expected: &MDConversionResult{
+				Markdown: "Page 1\nPage 2",
+				Length:   []uint32{2},
+				PositionData: &repository.PositionData{
+					PageDelimiters: []uint32{7, 13}, // "Page 1\n" = 7 chars, "Page 2" = 6 chars
 				},
 			},
-			suffix:   "\n",
-			expected: []string{"hello\n", "world\n", "test"},
 		},
 		{
-			name: "strings with existing suffix",
-			list: &structpb.ListValue{
-				Values: []*structpb.Value{
-					structpb.NewStringValue("hello\n"),
-					structpb.NewStringValue("world\n"),
-					structpb.NewStringValue("test"),
+			name: "fallback to convert_result2",
+			response: &structpb.Struct{
+				Fields: map[string]*structpb.Value{
+					"convert_result": structpb.NewListValue(&structpb.ListValue{
+						Values: []*structpb.Value{
+							structpb.NewStringValue("Page 1\n"),
+							structpb.NewStringValue("Page 2"),
+						},
+					}),
 				},
 			},
-			suffix:   "\n",
-			expected: []string{"hello\n", "world\n", "test"},
-		},
-		{
-			name: "empty strings filtered out",
-			list: &structpb.ListValue{
-				Values: []*structpb.Value{
-					structpb.NewStringValue("hello"),
-					structpb.NewStringValue(""),
-					structpb.NewStringValue("world"),
-					structpb.NewStringValue(""),
-					structpb.NewStringValue("test"),
+			expected: &MDConversionResult{
+				Markdown: "Page 1\nPage 2",
+				Length:   []uint32{2},
+				PositionData: &repository.PositionData{
+					PageDelimiters: []uint32{7, 13}, // "Page 1\n" = 7 chars, "Page 2" = 6 chars
 				},
 			},
-			suffix:   "",
-			expected: []string{"hello", "world", "test"},
 		},
 		{
-			name:     "nil list",
-			list:     nil,
-			suffix:   "",
-			expected: []string{},
+			name: "empty response",
+			response: &structpb.Struct{
+				Fields: map[string]*structpb.Value{},
+			},
+			expected: nil,
+			wantErr:  "no conversion result fields found in response",
+		},
+		{
+			name: "both fields empty",
+			response: &structpb.Struct{
+				Fields: map[string]*structpb.Value{
+					"convert_result":  structpb.NewStringValue(""),
+					"convert_result2": structpb.NewStringValue(""),
+				},
+			},
+			expected: nil,
+			wantErr:  "empty markdown string in conversion result",
 		},
 	}
 
 	for _, tt := range tests {
 		c.Run(tt.name, func(c *qt.C) {
-			result := ProtoListToStrings(tt.list, tt.suffix)
-			c.Assert(result, qt.DeepEquals, tt.expected)
-		})
-	}
-}
-
-func TestPositionDataFromPages(t *testing.T) {
-	c := qt.New(t)
-
-	tests := []struct {
-		name     string
-		pages    []string
-		expected *repository.PositionData
-	}{
-		{
-			name:     "empty pages",
-			pages:    []string{},
-			expected: nil,
-		},
-		{
-			name:     "nil pages",
-			pages:    nil,
-			expected: nil,
-		},
-		{
-			name:  "single page",
-			pages: []string{"hello world"},
-			expected: &repository.PositionData{
-				PageDelimiters: []uint32{11}, // "hello world" has 11 characters
-			},
-		},
-		{
-			name:  "multiple pages",
-			pages: []string{"hello", "world", "test"},
-			expected: &repository.PositionData{
-				PageDelimiters: []uint32{5, 10, 14}, // cumulative: 5, 5+5, 5+5+4
-			},
-		},
-		{
-			name:  "pages with unicode characters",
-			pages: []string{"héllo", "wörld", "tëst"},
-			expected: &repository.PositionData{
-				PageDelimiters: []uint32{5, 10, 14}, // unicode characters count as 1 rune each
-			},
-		},
-		{
-			name:  "empty pages filtered",
-			pages: []string{"hello", "", "world", "", "test"},
-			expected: &repository.PositionData{
-				PageDelimiters: []uint32{5, 5, 10, 10, 14}, // empty strings still count as pages
-			},
-		},
-		{
-			name:  "pages with newlines",
-			pages: []string{"hello\nworld", "test\ncase"},
-			expected: &repository.PositionData{
-				PageDelimiters: []uint32{11, 20}, // "hello\nworld" = 11 chars, "test\ncase" = 9 chars
-			},
-		},
-	}
-
-	for _, tt := range tests {
-		c.Run(tt.name, func(c *qt.C) {
-			result := PositionDataFromPages(tt.pages)
-			if tt.expected == nil {
-				c.Assert(result, qt.IsNil)
-			} else {
-				c.Assert(result, qt.DeepEquals, tt.expected)
+			// Create a mock response
+			resp := &pipelinepb.TriggerNamespacePipelineReleaseResponse{
+				Outputs: []*structpb.Struct{tt.response},
 			}
+
+			result, err := convertResultParser(resp)
+			if tt.wantErr != "" {
+				c.Assert(err, qt.IsNotNil)
+				c.Assert(err, qt.ErrorMatches, tt.wantErr)
+				return
+			}
+
+			c.Assert(err, qt.IsNil)
+			c.Assert(result, qt.DeepEquals, tt.expected)
 		})
 	}
 }

--- a/pkg/service/pipeline_release.go
+++ b/pkg/service/pipeline_release.go
@@ -78,7 +78,7 @@ var (
 	ConvertDocToMDPipeline = PipelineRelease{
 		Namespace: DefaultNamespaceID,
 		ID:        "indexing-advanced-convert-doc",
-		Version:   "v1.3.2",
+		Version:   "v1.4.0",
 	}
 
 	// ConvertDocToMDStandardPipeline is the default conversion pipeline for

--- a/pkg/service/preset/pipelines/indexing-advanced-convert-doc/v1.3.2/description.md
+++ b/pkg/service/preset/pipelines/indexing-advanced-convert-doc/v1.3.2/description.md
@@ -1,1 +1,0 @@
-Advanced RAG (Indexing Step 1): Convert a .pdf/.docx/.pptx/... file into the markdown string.

--- a/pkg/service/preset/pipelines/indexing-advanced-convert-doc/v1.4.0/description.md
+++ b/pkg/service/preset/pipelines/indexing-advanced-convert-doc/v1.4.0/description.md
@@ -1,0 +1,1 @@
+Advanced RAG (Indexing Step 1): Convert a .pdf/.docx/.pptx/... file into page-based markdown strings with position data.

--- a/pkg/service/preset/pipelines/indexing-advanced-convert-doc/v1.4.0/readme.md
+++ b/pkg/service/preset/pipelines/indexing-advanced-convert-doc/v1.4.0/readme.md
@@ -1,0 +1,26 @@
+# Advanced Document Conversion Pipeline v1.4.0
+
+## Overview
+
+This pipeline converts various page-based document formats (PDF, DOCX, DOC, PPT, PPTX) into markdown, respecting the page information. It's designed for advanced RAG (Retrieval-Augmented Generation) systems that require precise page-level document processing.
+
+## Key Features
+
+- **Page-based Processing**: Converts documents into arrays of markdown strings, one per page
+- **VLM Enhancement**: Uses Visual Language Models to improve OCR and text extraction quality
+- **Fallback Strategy**: Combines heuristic conversion with VLM refinement for optimal results
+
+## Pipeline Flow
+
+1. **Document Conversion**: Converts input document to both markdown and images
+3. **VLM Processing**: Uses OpenAI's GPT-4o to enhance text extraction and OCR
+4. **Result Collection**: Returns arrays of page-based markdown strings
+
+## Input Variables
+
+- `document_input`: The document file to be converted (PDF/DOCX/DOC/PPTX/PPT)
+
+## Output Fields
+
+- `convert_result`: Array of markdown strings (one per page) from VLM refinement
+- `convert_result2`: Array of markdown strings (one per page) from VLM OCR

--- a/pkg/service/preset/pipelines/indexing-advanced-convert-doc/v1.4.0/recipe.yaml
+++ b/pkg/service/preset/pipelines/indexing-advanced-convert-doc/v1.4.0/recipe.yaml
@@ -20,13 +20,13 @@ component:
     type: collection
     input:
       data: ${pages-to-images.output.images}
-      size: 2 # ${variable.image-batch-size}
+      size: 1
     task: TASK_SPLIT
   batch-markdown:
     type: collection
     input:
       data: ${pages-to-markdown.output.markdowns}
-      size: 2 # ${variable.image-batch-size}
+      size: 1
     task: TASK_SPLIT
     condition: ${pages-to-markdown.output.body} != ""
   vlm-refine-markdown:
@@ -35,12 +35,6 @@ component:
       start: 0
       stop: ${batch-images.output.data:length}
     component:
-      merge-batch-markdown:
-        type: json
-        input:
-          json-value: ${batch-markdown.output.data[i]}
-          jq-filter: join("\n")
-        task: TASK_JQ
       refine-markdown:
         type: openai
         task: TASK_TEXT_GENERATION
@@ -53,7 +47,7 @@ component:
 
             **Drafted Markdown Content**:
             ```
-            ${merge-batch-markdown.output.results}
+            ${batch-markdown.output.data[i]}
             ```
 
             **Guidelines**:
@@ -135,22 +129,10 @@ component:
     output-elements:
       result: ${document-ocr.output.texts[0]}
     condition: ${pages-to-markdown.output.body} == ""
-  merge-markdown-refinement:
-    type: json
-    input:
-      json-value: ${vlm-refine-markdown.output.result}
-      jq-filter: join("\n")
-    task: TASK_JQ
-  merge-markdown-ocr:
-    type: json
-    input:
-      json-value: ${vlm-document-ocr.output.result}
-      jq-filter: join("")
-    task: TASK_JQ
 output:
   convert_result:
     title: convert-result
-    value: ${merge-markdown-refinement.output.results[0]}
+    value: ${vlm-refine-markdown.output.result}
   convert_result2:
     title: convert-result2
-    value: ${merge-markdown-ocr.output.results[0]}
+    value: ${vlm-document-ocr.output.result}


### PR DESCRIPTION
Because

- The service layer is ready for adding the following metadata:
  - Page length to file
  - Page delimiters to converted file
  - Page references to chunk

This commit

- Adds utility functions for page extraction
- Returns one string per page on conversion pipeline
- Parses conversion results from pipeline
- Adds page length check in integration-tests
