### PR TITLE
feat(chunking): page by chunk when page delimiters are present

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/milvus-io/milvus-sdk-go/v2 v2.4.2
 	github.com/minio/minio-go/v7 v7.0.92
 	github.com/openfga/api/proto v0.0.0-20240723155248-7e5be7b65c27
+	github.com/pkoukk/tiktoken-go v0.1.8
 	github.com/redis/go-redis/v9 v9.9.0
 	go.uber.org/zap v1.27.0
 	golang.org/x/mod v0.25.0
@@ -34,6 +35,7 @@ require (
 require (
 	filippo.io/edwards25519 v1.1.0 // indirect
 	github.com/cenkalti/backoff/v5 v5.0.2 // indirect
+	github.com/dlclark/regexp2 v1.10.0 // indirect
 	github.com/go-playground/locales v0.14.1 // indirect
 	github.com/go-playground/universal-translator v0.18.1 // indirect
 	github.com/go-sql-driver/mysql v1.8.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -82,6 +82,8 @@ github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/r
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
 github.com/dhui/dktest v0.4.0 h1:z05UmuXZHO/bgj/ds2bGMBu8FI4WA+Ag/m3ghL+om7M=
 github.com/dhui/dktest v0.4.0/go.mod h1:v/Dbz1LgCBOi2Uki2nUqLBGa83hWBGFMu5MrgMDCc78=
+github.com/dlclark/regexp2 v1.10.0 h1:+/GIL799phkJqYW+3YbOd8LCcbHzT0Pbo8zl70MHsq0=
+github.com/dlclark/regexp2 v1.10.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/docker/distribution v2.8.2+incompatible h1:T3de5rq0dB1j30rp0sA2rER+m322EBzniBPB6ZIzuh8=
 github.com/docker/distribution v2.8.2+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/docker v24.0.7+incompatible h1:Wo6l37AuwP3JaMnZa226lzVXGA3F9Ig1seQen0cKYlM=
@@ -449,6 +451,8 @@ github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pkoukk/tiktoken-go v0.1.8 h1:85ENo+3FpWgAACBaEUVp+lctuTcYUO7BtmfhlN/QTRo=
+github.com/pkoukk/tiktoken-go v0.1.8/go.mod h1:9NiV+i9mJKGj1rYOT+njbv+ZwA/zJxYdewGl6qVatpg=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/pkg/service/pagesplitter.go
+++ b/pkg/service/pagesplitter.go
@@ -1,0 +1,56 @@
+package service
+
+import (
+	"fmt"
+
+	"github.com/pkoukk/tiktoken-go"
+
+	"github.com/instill-ai/artifact-backend/pkg/repository"
+)
+
+// PageSplitter can split a string into chunks according to a set of delimiters
+// (i.e., byte positions).
+type PageSplitter struct {
+	PageDelimiters []uint32
+}
+
+// Split breaks a string into chunks according to the splitter's delimiters.
+// Chunks with empty text are skipped.
+func (ps *PageSplitter) Split(content string) ([]Chunk, error) {
+	chunks := make([]Chunk, 0, len(ps.PageDelimiters))
+	runes := []rune(content)
+
+	var start uint32
+	for i, delim := range ps.PageDelimiters {
+		if int(delim) > len(runes) {
+			return nil, fmt.Errorf("page delimiter exceeds content size")
+		}
+
+		page := uint32(i + 1) // pages are 1-indexed
+		text := string(runes[start:delim])
+		if len(text) == 0 {
+			continue
+		}
+
+		tkm, err := tiktoken.EncodingForModel("gpt-4") // same model as in the chunking recipes
+		if err != nil {
+			return nil, fmt.Errorf("unsupported encoding model: %w", err)
+		}
+		tokenCount := len(tkm.Encode(text, nil, nil))
+
+		chunk := Chunk{
+			Start:  int(start),
+			End:    int(delim),
+			Text:   text,
+			Tokens: tokenCount,
+			Reference: &repository.ChunkReference{
+				PageRange: [2]uint32{page, page},
+			},
+		}
+		chunks = append(chunks, chunk)
+
+		start = delim
+	}
+
+	return chunks, nil
+}

--- a/pkg/service/pagesplitter_test.go
+++ b/pkg/service/pagesplitter_test.go
@@ -1,0 +1,291 @@
+package service
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/instill-ai/artifact-backend/pkg/repository"
+)
+
+func TestPageSplitter_Split(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name           string
+		pageDelimiters []uint32
+		content        string
+		expected       []Chunk
+		wantErr        string
+	}{
+		{
+			name:           "single page",
+			pageDelimiters: []uint32{5},
+			content:        "Hello",
+			expected: []Chunk{
+				{
+					Start:  0,
+					End:    5,
+					Text:   "Hello",
+					Tokens: 1, // "Hello" = 1 token
+					Reference: &repository.ChunkReference{
+						PageRange: [2]uint32{1, 1},
+					},
+				},
+			},
+		},
+		{
+			name:           "multiple pages",
+			pageDelimiters: []uint32{5, 10},
+			content:        "HelloWorld",
+			expected: []Chunk{
+				{
+					Start:  0,
+					End:    5,
+					Text:   "Hello",
+					Tokens: 1, // "Hello" = 1 token
+					Reference: &repository.ChunkReference{
+						PageRange: [2]uint32{1, 1},
+					},
+				},
+				{
+					Start:  5,
+					End:    10,
+					Text:   "World",
+					Tokens: 1, // "World" = 1 token
+					Reference: &repository.ChunkReference{
+						PageRange: [2]uint32{2, 2},
+					},
+				},
+			},
+		},
+		{
+			name:           "empty content",
+			pageDelimiters: []uint32{0},
+			content:        "",
+			expected:       []Chunk{}, // empty chunks are skipped
+		},
+		{
+			name:           "unicode content",
+			pageDelimiters: []uint32{2, 4},
+			content:        "你好世界",
+			expected: []Chunk{
+				{
+					Start:  0,
+					End:    2,
+					Text:   "你好",
+					Tokens: 2, // "你好" = 2 tokens
+					Reference: &repository.ChunkReference{
+						PageRange: [2]uint32{1, 1},
+					},
+				},
+				{
+					Start:  2,
+					End:    4,
+					Text:   "世界",
+					Tokens: 3, // "世界" = 3 tokens
+					Reference: &repository.ChunkReference{
+						PageRange: [2]uint32{2, 2},
+					},
+				},
+			},
+		},
+		{
+			name:           "content with newlines",
+			pageDelimiters: []uint32{6, 12},
+			content:        "Line 1\nLine 2",
+			expected: []Chunk{
+				{
+					Start:  0,
+					End:    6,
+					Text:   "Line 1",
+					Tokens: 3, // "Line 1" = 3 tokens
+					Reference: &repository.ChunkReference{
+						PageRange: [2]uint32{1, 1},
+					},
+				},
+				{
+					Start:  6,
+					End:    12,
+					Text:   "\nLine ",
+					Tokens: 3, // "\nLine " = 3 tokens
+					Reference: &repository.ChunkReference{
+						PageRange: [2]uint32{2, 2},
+					},
+				},
+			},
+		},
+		{
+			name:           "delimiter exceeds content size",
+			pageDelimiters: []uint32{5, 20},
+			content:        "Hello",
+			expected:       nil,
+			wantErr:        "page delimiter exceeds content size",
+		},
+		{
+			name:           "no delimiters",
+			pageDelimiters: []uint32{},
+			content:        "Hello",
+			expected:       []Chunk{},
+		},
+		{
+			name:           "delimiter at content boundary",
+			pageDelimiters: []uint32{5},
+			content:        "Hello",
+			expected: []Chunk{
+				{
+					Start:  0,
+					End:    5,
+					Text:   "Hello",
+					Tokens: 1,
+					Reference: &repository.ChunkReference{
+						PageRange: [2]uint32{1, 1},
+					},
+				},
+			},
+		},
+		{
+			name:           "multiple delimiters with same position",
+			pageDelimiters: []uint32{5, 5, 10},
+			content:        "HelloWorld",
+			expected: []Chunk{
+				{
+					Start:  0,
+					End:    5,
+					Text:   "Hello",
+					Tokens: 1,
+					Reference: &repository.ChunkReference{
+						PageRange: [2]uint32{1, 1},
+					},
+				},
+				{
+					Start:  5,
+					End:    10,
+					Text:   "World",
+					Tokens: 1,
+					Reference: &repository.ChunkReference{
+						PageRange: [2]uint32{3, 3},
+					},
+				},
+			},
+		},
+		{
+			name:           "all empty chunks",
+			pageDelimiters: []uint32{0, 0, 0},
+			content:        "",
+			expected:       []Chunk{},
+		},
+		{
+			name:           "mixed empty and non-empty chunks",
+			pageDelimiters: []uint32{0, 5, 5},
+			content:        "Hello",
+			expected: []Chunk{
+				{
+					Start:  0,
+					End:    5,
+					Text:   "Hello",
+					Tokens: 1,
+					Reference: &repository.ChunkReference{
+						PageRange: [2]uint32{2, 2},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		c.Run(tt.name, func(c *qt.C) {
+			splitter := &PageSplitter{
+				PageDelimiters: tt.pageDelimiters,
+			}
+
+			result, err := splitter.Split(tt.content)
+			if tt.wantErr != "" {
+				c.Assert(err, qt.IsNotNil)
+				c.Assert(err, qt.ErrorMatches, tt.wantErr)
+				return
+			}
+
+			c.Assert(err, qt.IsNil)
+			c.Assert(result, qt.DeepEquals, tt.expected)
+		})
+	}
+}
+
+func TestPageSplitter_Split_EdgeCases(t *testing.T) {
+	c := qt.New(t)
+
+	c.Run("special characters", func(c *qt.C) {
+		content := "Hello\tWorld\nTest\r\nEnd"
+		splitter := &PageSplitter{
+			PageDelimiters: []uint32{5, 11, 16, 20},
+		}
+
+		result, err := splitter.Split(content)
+		c.Assert(err, qt.IsNil)
+		c.Assert(len(result), qt.Equals, 4)
+
+		expectedTexts := []string{"Hello", "\tWorld", "\nTest", "\r\nEn"}
+		for i, expected := range expectedTexts {
+			c.Assert(result[i].Text, qt.Equals, expected)
+		}
+	})
+}
+
+func TestPageSplitter_Split_RealLife(t *testing.T) {
+	c := qt.New(t)
+
+	c.Run("EU Council document with page delimiters", func(c *qt.C) {
+		// Read the input content from testdata
+		inputPath := filepath.Join("testdata", "page-splitter-input.md")
+		content, err := os.ReadFile(inputPath)
+		c.Assert(err, qt.IsNil, qt.Commentf("Failed to read input file: %s", inputPath))
+
+		splitter := &PageSplitter{
+			PageDelimiters: []uint32{1232, 3853, 5974, 8058},
+		}
+
+		result, err := splitter.Split(string(content))
+		c.Assert(err, qt.IsNil)
+		c.Assert(len(result), qt.Equals, 4)
+
+		// Expected values for verification
+		expectedTokenCounts := []int{328, 484, 391, 365}
+		expectedStartPositions := []int{0, 1232, 3853, 5974}
+		expectedEndPositions := []int{1232, 3853, 5974, 8058}
+		expectedOutputs := []string{
+			"page-splitter-output-1.txt",
+			"page-splitter-output-2.txt",
+			"page-splitter-output-3.txt",
+			"page-splitter-output-4.txt",
+		}
+
+		// Verify all chunk properties in a single loop
+		for i, chunk := range result {
+			expectedPage := uint32(i + 1)
+
+			// Verify token count
+			c.Assert(chunk.Tokens, qt.Equals, expectedTokenCounts[i], qt.Commentf("Chunk %d token count mismatch", i+1))
+
+			// Verify page ranges are correct (1-indexed)
+			c.Assert(chunk.Reference.PageRange[0], qt.Equals, expectedPage)
+			c.Assert(chunk.Reference.PageRange[1], qt.Equals, expectedPage)
+
+			// Verify that chunks are non-empty
+			c.Assert(chunk.Text, qt.Not(qt.Equals), "", qt.Commentf("Chunk %d should not be empty", i+1))
+			c.Assert(len(chunk.Text), qt.Not(qt.Equals), 0, qt.Commentf("Chunk %d should have content", i+1))
+
+			// Verify start/end positions are correct
+			c.Assert(chunk.Start, qt.Equals, expectedStartPositions[i], qt.Commentf("Chunk %d start position mismatch", i+1))
+			c.Assert(chunk.End, qt.Equals, expectedEndPositions[i], qt.Commentf("Chunk %d end position mismatch", i+1))
+
+			// Verify against expected output files
+			outputPath := filepath.Join("testdata", expectedOutputs[i])
+			expectedContent, err := os.ReadFile(outputPath)
+			c.Assert(err, qt.IsNil, qt.Commentf("Failed to read expected output file: %s", outputPath))
+			c.Assert(chunk.Text, qt.Equals, string(expectedContent), qt.Commentf("Chunk %d content doesn't match expected output", i+1))
+		}
+	})
+}

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -21,8 +21,8 @@ type Service interface {
 	CheckNamespacePermission(context.Context, *resource.Namespace) error
 	ConvertToMDPipe(context.Context, MDConversionParams) (*MDConversionResult, error)
 	GenerateSummary(_ context.Context, content, fileType string) (string, error)
-	ChunkMarkdownPipe(_ context.Context, markdown string) ([]Chunk, error)
-	ChunkTextPipe(_ context.Context, text string) ([]Chunk, error)
+	ChunkMarkdownPipe(_ context.Context, markdown string) (*ChunkingResult, error)
+	ChunkTextPipe(_ context.Context, text string) (*ChunkingResult, error)
 	EmbeddingTextPipe(_ context.Context, texts []string) ([][]float32, error)
 	QuestionAnsweringPipe(_ context.Context, question string, simChunks []string) (string, error)
 	SimilarityChunksSearch(_ context.Context, ownerUID uuid.UUID, _ *artifactpb.SimilarityChunksSearchRequest) ([]SimChunk, error)

--- a/pkg/service/testdata/page-splitter-input.md
+++ b/pkg/service/testdata/page-splitter-input.md
@@ -1,0 +1,103 @@
+## Council of the European Union
+
+Brussels, 21 October 2020  
+(OR. en)  
+12143/20  
+
+**LIMITE**  
+
+- JAI 851  
+- COSI 156  
+- CATS 73  
+- ENFOPOL 256  
+- COPEN 287  
+- DATAPROTECT 106  
+- CYBER 198  
+- IXIM 107  
+
+---
+
+**NOTE**
+
+**From:** Presidency  
+**To:** Delegations  
+**Subject:** Draft Council Declaration on Encryption  
+- Security through encryption and security despite encryption  
+
+Further to the informal VTC of the members of the Standing Committee on Operational Cooperation on Internal Security (COSI) on 23 September 2020, delegations will find in the Annex a Draft Council Declaration on Encryption.
+
+The draft Declaration is based on the Presidency discussion paper submitted to COSI (10728/20) and the written contributions received by delegations (WK 11169/20). It also takes into account the joint paper of the COM services presented by DG Home and DG Just (10730/20), as well as the contribution of the EU CTC (7675/20).
+
+Delegations are invited to submit written comments and concrete drafting suggestions on the Draft Council Declaration set out in the Annex before 29 October 2020 (COB) to paul.gaitzsch@diplo.de; COSI.DE2020@bmi.bund.de and cosi@consilium.europa.eu
+
+---
+
+12143/20 MP/dk  
+JAI.1 LIMITE EN
+## ANNEX
+
+### Draft Council Declaration on Encryption
+
+**Security through encryption and security despite encryption**
+
+1. **Preamble: Security through encryption and security despite encryption**
+
+   The European Union fully supports the development, implementation and use of strong encryption. Encryption is a necessary means of protecting fundamental rights and the digital security of governments, industry and society. At the same time, the European Union needs to preserve the ability of law enforcement and judicial authorities to exercise their lawful powers, both online and offline.
+
+   According to the European Council conclusions, 1-2 October 2020, EUCO 13/20, *the EU will leverage its tools and regulatory powers to help shape global rules and standards*. It was agreed to use funds under the Recovery and Resilience Facility to advance objectives such as *enhancing the EU’s ability to protect itself against cyber threats, to provide for a secure communication environment, especially through quantum encryption, and to ensure access to data for judicial and law enforcement purposes*.
+
+2. **Current use/state of encryption**
+
+   In today’s world, encryption technology is increasingly used in all areas of public and private life. This is a means to protect governments, civil society, citizens and industry by ensuring the privacy and security of communications and personal data: all parties benefit from high-performance encryption technology. Encryption has been identified by EU data protection authorities as an important tool contributing for instance to the protection of personal data transferred outside of the EU against (disproportionate) government access, which according to the Court of Justice is a legal requirement for data transfers[^1]. Not only is the user data on electronic devices encrypted, but more and more communication channels are also secured by end-to-end (E2E) encryption. The majority of instant messaging apps on online platforms have equally implemented end-to-end encryption.
+
+[^1]: Judgment of 16 July 2020 in Case C-311/18 Data Protection Commissioner v Facebook Ireland Ltd, Maximillian Schrems, ECLI:EU:C:2020:559
+
+---
+
+**Image Description**: The image contains a page from a document titled "ANNEX Draft Council Declaration on Encryption." It discusses the European Union's stance on encryption, emphasizing the balance between security through encryption and the need for law enforcement access. The document references European Council conclusions from October 2020 and highlights the importance of encryption in protecting personal data and communications.
+## 3. Challenges for Ensuring Public Safety
+
+The "digital life" is a source not only of great opportunities, but also of considerable challenges: the digitalisation of modern societies brings with it certain vulnerabilities and the potential for abuse in cyberspace. Thus criminals can make use of readily available, off-the-shelf encryption solutions conceived for legitimate purposes, including as part of their *modi operandi*.
+
+At the same time, law enforcement is increasingly dependent on access to electronic evidence to fight effectively terrorism, organised crime, child sexual abuse, particularly its online aspects or any cyber-enabled crime and bring criminals to justice.
+
+In practice, there are instances where encryption application renders analysis of the content of communications in the framework of access to electronic evidence extremely challenging.
+
+Independently of the technological environment of the day, it is therefore essential to preserve the powers of law enforcement and judicial authorities through lawful access to carry out their tasks, as prescribed and authorised by law. Such laws providing for the enforcement powers must always fully respect due process and other safeguards, as well as other freedoms and rights, in particular the right to respect for private life and communications and the right to the protection of personal data.
+
+## 4. Creating a Balance
+
+The principle of security through encryption and security despite encryption must be upheld in its entirety. The European Union continues to support strong encryption. Encryption is an anchor of confidence in digitalisation and should be promoted and developed.
+
+Protecting the privacy and security of communications through encryption and at the same time upholding the possibility for law enforcement and judicial authorities to lawfully access relevant data for legitimate, clearly defined purposes of fighting serious crimes, in the digital world, are extremely important. Any actions taken have to balance these interests carefully.
+
+---
+
+*Footnote:*
+
+2. iOCTA 2020, p. 25
+
+---
+
+12143/20 MP/dk 3  
+JAI.1 LIMITE EN
+## 5. Joining forces with the tech industry
+
+Moving forward, the European Union strives to establish an active discussion with the technology industry to ensure the continued implementation and use of strong encryption technology. Law enforcement and judicial authorities must be able to access data in a lawful and targeted manner, in full respect of fundamental rights and data protection regime, while upholding cybersecurity. Technical solutions for gaining access to encrypted data must match the principles of legality, necessity, and proportionality.
+
+Since there is no single way of achieving the set goals, governments and industry need to work together to create this balance.
+
+## 6. Legal framework
+
+There is a need for a regulatory framework that safeguards fundamental rights and the advantages of end-to-end encryption and which allows law enforcement and judicial authorities to carry out their tasks. Possible solutions may need the support of service providers in a transparent and lawful manner, as well as improving the technical and tactical skills which the law enforcement and judicial authorities need to face the challenges of digitisation at a global scale. In line with the principle of proportionality, such measures should be prioritised.
+
+Developing technical tools aimed at supporting criminal proceedings could also be considered. Such technical tools should be subject to the principles outlined in this declaration.
+
+## 7. Innovative investigative capabilities
+
+It is of paramount importance that this matter is handled in a coordinated way at EU level in order to combine the efforts of all Member States and EU institutions and bodies to define and establish innovative approaches and best practice to respond to these challenges. Technical solutions anchored on the principles of necessity and proportionality should be developed in close consultation with service providers and the relevant authorities, while there should be no single prescribed technical solution to provide access to the encrypted data.
+
+---
+
+12143/20 MP/dk 4  
+JAI.1 LIMITE EN

--- a/pkg/service/testdata/page-splitter-output-1.txt
+++ b/pkg/service/testdata/page-splitter-output-1.txt
@@ -1,0 +1,36 @@
+## Council of the European Union
+
+Brussels, 21 October 2020  
+(OR. en)  
+12143/20  
+
+**LIMITE**  
+
+- JAI 851  
+- COSI 156  
+- CATS 73  
+- ENFOPOL 256  
+- COPEN 287  
+- DATAPROTECT 106  
+- CYBER 198  
+- IXIM 107  
+
+---
+
+**NOTE**
+
+**From:** Presidency  
+**To:** Delegations  
+**Subject:** Draft Council Declaration on Encryption  
+- Security through encryption and security despite encryption  
+
+Further to the informal VTC of the members of the Standing Committee on Operational Cooperation on Internal Security (COSI) on 23 September 2020, delegations will find in the Annex a Draft Council Declaration on Encryption.
+
+The draft Declaration is based on the Presidency discussion paper submitted to COSI (10728/20) and the written contributions received by delegations (WK 11169/20). It also takes into account the joint paper of the COM services presented by DG Home and DG Just (10730/20), as well as the contribution of the EU CTC (7675/20).
+
+Delegations are invited to submit written comments and concrete drafting suggestions on the Draft Council Declaration set out in the Annex before 29 October 2020 (COB) to paul.gaitzsch@diplo.de; COSI.DE2020@bmi.bund.de and cosi@consilium.europa.eu
+
+---
+
+12143/20 MP/dk  
+JAI.1 LIMITE EN

--- a/pkg/service/testdata/page-splitter-output-2.txt
+++ b/pkg/service/testdata/page-splitter-output-2.txt
@@ -1,0 +1,21 @@
+## ANNEX
+
+### Draft Council Declaration on Encryption
+
+**Security through encryption and security despite encryption**
+
+1. **Preamble: Security through encryption and security despite encryption**
+
+   The European Union fully supports the development, implementation and use of strong encryption. Encryption is a necessary means of protecting fundamental rights and the digital security of governments, industry and society. At the same time, the European Union needs to preserve the ability of law enforcement and judicial authorities to exercise their lawful powers, both online and offline.
+
+   According to the European Council conclusions, 1-2 October 2020, EUCO 13/20, *the EU will leverage its tools and regulatory powers to help shape global rules and standards*. It was agreed to use funds under the Recovery and Resilience Facility to advance objectives such as *enhancing the EU’s ability to protect itself against cyber threats, to provide for a secure communication environment, especially through quantum encryption, and to ensure access to data for judicial and law enforcement purposes*.
+
+2. **Current use/state of encryption**
+
+   In today’s world, encryption technology is increasingly used in all areas of public and private life. This is a means to protect governments, civil society, citizens and industry by ensuring the privacy and security of communications and personal data: all parties benefit from high-performance encryption technology. Encryption has been identified by EU data protection authorities as an important tool contributing for instance to the protection of personal data transferred outside of the EU against (disproportionate) government access, which according to the Court of Justice is a legal requirement for data transfers[^1]. Not only is the user data on electronic devices encrypted, but more and more communication channels are also secured by end-to-end (E2E) encryption. The majority of instant messaging apps on online platforms have equally implemented end-to-end encryption.
+
+[^1]: Judgment of 16 July 2020 in Case C-311/18 Data Protection Commissioner v Facebook Ireland Ltd, Maximillian Schrems, ECLI:EU:C:2020:559
+
+---
+
+**Image Description**: The image contains a page from a document titled "ANNEX Draft Council Declaration on Encryption." It discusses the European Union's stance on encryption, emphasizing the balance between security through encryption and the need for law enforcement access. The document references European Council conclusions from October 2020 and highlights the importance of encryption in protecting personal data and communications.

--- a/pkg/service/testdata/page-splitter-output-3.txt
+++ b/pkg/service/testdata/page-splitter-output-3.txt
@@ -1,0 +1,26 @@
+## 3. Challenges for Ensuring Public Safety
+
+The "digital life" is a source not only of great opportunities, but also of considerable challenges: the digitalisation of modern societies brings with it certain vulnerabilities and the potential for abuse in cyberspace. Thus criminals can make use of readily available, off-the-shelf encryption solutions conceived for legitimate purposes, including as part of their *modi operandi*.
+
+At the same time, law enforcement is increasingly dependent on access to electronic evidence to fight effectively terrorism, organised crime, child sexual abuse, particularly its online aspects or any cyber-enabled crime and bring criminals to justice.
+
+In practice, there are instances where encryption application renders analysis of the content of communications in the framework of access to electronic evidence extremely challenging.
+
+Independently of the technological environment of the day, it is therefore essential to preserve the powers of law enforcement and judicial authorities through lawful access to carry out their tasks, as prescribed and authorised by law. Such laws providing for the enforcement powers must always fully respect due process and other safeguards, as well as other freedoms and rights, in particular the right to respect for private life and communications and the right to the protection of personal data.
+
+## 4. Creating a Balance
+
+The principle of security through encryption and security despite encryption must be upheld in its entirety. The European Union continues to support strong encryption. Encryption is an anchor of confidence in digitalisation and should be promoted and developed.
+
+Protecting the privacy and security of communications through encryption and at the same time upholding the possibility for law enforcement and judicial authorities to lawfully access relevant data for legitimate, clearly defined purposes of fighting serious crimes, in the digital world, are extremely important. Any actions taken have to balance these interests carefully.
+
+---
+
+*Footnote:*
+
+2. iOCTA 2020, p. 25
+
+---
+
+12143/20 MP/dk 3  
+JAI.1 LIMITE EN

--- a/pkg/service/testdata/page-splitter-output-4.txt
+++ b/pkg/service/testdata/page-splitter-output-4.txt
@@ -1,0 +1,20 @@
+## 5. Joining forces with the tech industry
+
+Moving forward, the European Union strives to establish an active discussion with the technology industry to ensure the continued implementation and use of strong encryption technology. Law enforcement and judicial authorities must be able to access data in a lawful and targeted manner, in full respect of fundamental rights and data protection regime, while upholding cybersecurity. Technical solutions for gaining access to encrypted data must match the principles of legality, necessity, and proportionality.
+
+Since there is no single way of achieving the set goals, governments and industry need to work together to create this balance.
+
+## 6. Legal framework
+
+There is a need for a regulatory framework that safeguards fundamental rights and the advantages of end-to-end encryption and which allows law enforcement and judicial authorities to carry out their tasks. Possible solutions may need the support of service providers in a transparent and lawful manner, as well as improving the technical and tactical skills which the law enforcement and judicial authorities need to face the challenges of digitisation at a global scale. In line with the principle of proportionality, such measures should be prioritised.
+
+Developing technical tools aimed at supporting criminal proceedings could also be considered. Such technical tools should be subject to the principles outlined in this declaration.
+
+## 7. Innovative investigative capabilities
+
+It is of paramount importance that this matter is handled in a coordinated way at EU level in order to combine the efforts of all Member States and EU institutions and bodies to define and establish innovative approaches and best practice to respond to these challenges. Technical solutions anchored on the principles of necessity and proportionality should be developed in close consultation with service providers and the relevant authorities, while there should be no single prescribed technical solution to provide access to the encrypted data.
+
+---
+
+12143/20 MP/dk 4  
+JAI.1 LIMITE EN


### PR DESCRIPTION
Because

- Page chunking performs well for a wide variety of documents and allows
  for simpler references

This commit

- Refactors the chunking step to simplify the switch condition
- Instead of chunking through a pipeline and positioning the chunks
  within the document pages, when page delimiters are present the
  markdown text is split with them (removing the need for a pipeline
  call).
