### PR TITLE
chore(blob): make file blob paths more descriptive

### DIFF
--- a/pkg/handler/knowledgebase.go
+++ b/pkg/handler/knowledgebase.go
@@ -392,8 +392,7 @@ func (ph *PublicHandler) DeleteCatalog(ctx context.Context, req *artifactpb.Dele
 		logger.Info("DeleteCatalog starts in background", zap.String("catalog_id", kb.UID.String()))
 		allPass := true
 		//  delete files in minIO
-		err = <-ph.service.MinIO().DeleteKnowledgeBase(ctx, kb.UID)
-		if err != nil {
+		if err := ph.service.MinIO().DeleteKnowledgeBase(ctx, kb.UID); err != nil {
 			logger.Error("failed to delete files in minIO in background", zap.Error(err))
 			allPass = false
 		}


### PR DESCRIPTION
This commit:

- Updates the converted file and chunk blob paths to be more descriptive
  - From `{kbUID}/{fileUID}/converted-file/{convFileUID}`
  - To `kb-{kbUID}/file-{fileUID}/converted-file/{convFileUID}`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switch MinIO blob paths to `kb-{kbUID}/file-{fileUID}/...`, add legacy cleanup, and change `DeleteKnowledgeBase` to return an error with handler updated accordingly.
> 
> - **Storage (MinIO)**:
>   - **Blob paths**: Change base paths to `kb-{kbUID}/file-{fileUID}/converted-file` and `.../chunk` via `fileBasePath()`; update `convertedFileBasePath()` and `chunkBasePath()`.
>   - **Deletion**: `DeleteKnowledgeBase(ctx, kbUID)` now returns `error` and deletes both new (`kb-{kbUID}`) and legacy (`{kbUID}`) prefixes using `collectErrors`.
> - **Handler**:
>   - Update `DeleteCatalog` to call `MinIO().DeleteKnowledgeBase` with direct `error` handling (no channel).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c712a94d17d74169b14d8db269a68d109a920564. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->