### PR TITLE
fix(handler): replace embedded owner/creator with denormalized display fields

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/grpc-ecosystem/go-grpc-middleware v1.4.0
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.1
 	github.com/iancoleman/strcase v0.3.0
-	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20260407175141-8de4bdc74b8f
+	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20260413191818-c327edfe2e46
 	github.com/instill-ai/x v0.10.1-alpha.0.20260316103754-d72af039ae90
 	github.com/knadh/koanf v1.5.0
 	github.com/mennanov/fieldmask-utils v1.1.2

--- a/go.sum
+++ b/go.sum
@@ -419,8 +419,8 @@ github.com/iancoleman/strcase v0.3.0 h1:nTXanmYxhfFAMjZL34Ov6gkzEsSJZ5DbhxWjvSAS
 github.com/iancoleman/strcase v0.3.0/go.mod h1:iwCmte+B7n89clKwxIoIXy/HfoL7AsD47ZCWhYzw7ho=
 github.com/imkira/go-interpol v1.1.0/go.mod h1:z0h2/2T3XF8kyEPpRgJ3kmNv+C43p+I/CoI+jC3w2iA=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20260407175141-8de4bdc74b8f h1:rtfnvqhGHYbQi+ksjWyoWjr+gtzHcMPuwAP379wE1T8=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20260407175141-8de4bdc74b8f/go.mod h1:bCnBosofpaUxKBuTTJM3/I3thAK37kvfBnKByjnLsl4=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20260413191818-c327edfe2e46 h1:fXCDFN8KINRuk+F1wJ6eV9+c25ngwfaS4R/l1ZEndOo=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20260413191818-c327edfe2e46/go.mod h1:bCnBosofpaUxKBuTTJM3/I3thAK37kvfBnKByjnLsl4=
 github.com/instill-ai/x v0.10.1-alpha.0.20260316103754-d72af039ae90 h1:jFBx6cSkJ2GM8JV8IYUEZfAXamOe2yCrWTM9aHb8R2I=
 github.com/instill-ai/x v0.10.1-alpha.0.20260316103754-d72af039ae90/go.mod h1:l66X/UwzzmzCHeZhkjrlxN44IZFMuu2E/k3TeQi+TO8=
 github.com/iris-contrib/blackfriday v2.0.0+incompatible/go.mod h1:UzZ2bDEoaSGPbkg6SAB4att1aAwTmVIx/5gCVqeyUdI=

--- a/integration-test/helper.js
+++ b/integration-test/helper.js
@@ -571,30 +571,22 @@ export function validateFile(file, isPrivate) {
     return false;
   }
 
-  // Note: ownerUid field removed in AIP refactoring - use owner object instead
-
   // Validate ownerName field (required)
   if (!("ownerName" in file)) {
     console.log("File has no ownerName field");
     return false;
   }
 
-  // Validate owner object (optional but if present, must be valid)
-  if ("owner" in file && file.owner !== null && file.owner !== undefined) {
-    if (!file.owner.user && !file.owner.organization) {
-      console.log("File owner is neither user nor organization");
-      return false;
-    }
+  // Validate denormalized owner display fields (replaced embedded owner object)
+  if ("ownerDisplayName" in file && typeof file.ownerDisplayName !== 'string') {
+    console.log("File ownerDisplayName is not a string");
+    return false;
   }
 
-  // Note: creatorUid field removed in AIP refactoring - use creator object instead
-
-  // Validate creator object (optional, but if present must be valid User)
-  if ("creator" in file && file.creator !== null && file.creator !== undefined) {
-    if (!isValidCreator(file.creator)) {
-      console.log("File creator is not a valid User object");
-      return false;
-    }
+  // Validate denormalized creator display fields (replaced embedded creator object)
+  if ("creatorDisplayName" in file && typeof file.creatorDisplayName !== 'string') {
+    console.log("File creatorDisplayName is not a string");
+    return false;
   }
 
   // Validate knowledgeBaseIds field (many-to-many relationship, should be array if present)
@@ -740,22 +732,16 @@ export function validateFileGRPC(file, isPrivate) {
     }
   }
 
-  // Validate owner object (optional but if present, must be valid)
-  if ("owner" in file && file.owner !== null && file.owner !== undefined) {
-    if (!file.owner.user && !file.owner.organization) {
-      console.log("File owner is neither user nor organization");
-      return false;
-    }
+  // Validate denormalized owner display fields (replaced embedded owner object)
+  if ("ownerDisplayName" in file && typeof file.ownerDisplayName !== 'string') {
+    console.log("File ownerDisplayName is not a string");
+    return false;
   }
 
-  // Note: creatorUid field removed in AIP refactoring - use creator object instead
-
-  // Validate creator object (optional, but if present must be valid User)
-  if ("creator" in file && file.creator !== null && file.creator !== undefined) {
-    if (!isValidCreator(file.creator)) {
-      console.log("File creator is not a valid User object");
-      return false;
-    }
+  // Validate denormalized creator display fields (replaced embedded creator object)
+  if ("creatorDisplayName" in file && typeof file.creatorDisplayName !== 'string') {
+    console.log("File creatorDisplayName is not a string");
+    return false;
   }
 
   // Validate knowledgeBases field (optional, should be array if present)

--- a/integration-test/rest.js
+++ b/integration-test/rest.js
@@ -541,7 +541,8 @@ export function TEST_08_E2EKnowledgeBase(data) {
         [`E2E: File has valid structure (${s.originalName})`]: () => file && helper.validateFile(file, false),
         // Note: ownerUid and creatorUid removed in AIP refactoring
         [`E2E: File ownerName matches namespace (${s.originalName})`]: () => file && file.ownerName === `users/${data.expectedOwner.id}`,
-        [`E2E: File has valid creator object (${s.originalName})`]: () => file && helper.isValidCreator(file.creator, data.expectedOwner),
+        [`E2E: File has ownerDisplayName (${s.originalName})`]: () => file && typeof file.ownerDisplayName === 'string' && file.ownerDisplayName.length > 0,
+        [`E2E: File has creatorDisplayName (${s.originalName})`]: () => file && typeof file.creatorDisplayName === 'string' && file.creatorDisplayName.length > 0,
       });
       // Note: uid removed in AIP refactoring - use id for identification
       if (file && file.id) {
@@ -635,7 +636,8 @@ export function TEST_08_E2EKnowledgeBase(data) {
               fileData.totalChunks > 0 && fileData.totalTokens > 0,
             // Owner/Creator validations on file list (ownerUid and creatorUid removed in AIP refactoring)
             [`E2E: Listed file ownerName matches namespace (${f.type})`]: () => fileData && fileData.ownerName === `users/${data.expectedOwner.id}`,
-            [`E2E: Listed file has valid creator (${f.type})`]: () => fileData && helper.isValidCreator(fileData.creator, data.expectedOwner),
+            [`E2E: Listed file has ownerDisplayName (${f.type})`]: () => fileData && typeof fileData.ownerDisplayName === 'string' && fileData.ownerDisplayName.length > 0,
+            [`E2E: Listed file has creatorDisplayName (${f.type})`]: () => fileData && typeof fileData.creatorDisplayName === 'string' && fileData.creatorDisplayName.length > 0,
           });
         } catch (e) {
           console.log(`E2E: Error verifying metadata for ${f.filename} (${f.type}): ${e}`);
@@ -1640,15 +1642,14 @@ export function TEST_23_OwnerCreatorFields(data) {
     let fileJson; try { fileJson = fileRes.json(); } catch (e) { fileJson = {}; }
     const file = fileJson.file || {};
 
-    // Validate file owner/creator fields (ownerUid and creatorUid removed in AIP refactoring)
+    // Validate file denormalized display fields (embedded owner/creator objects removed for data leakage prevention)
     check(fileRes, {
       "File: Response status is 200": (r) => r.status === 200,
       "File: ownerName matches namespace path": () => file && file.ownerName === `users/${data.expectedOwner.id}`,
-      "File: owner object exists and is valid": () => file && file.owner && file.owner.user,
-      "File: owner.user.id matches expected user": () => file && file.owner && file.owner.user && file.owner.user.id === data.expectedOwner.id,
-      "File: creator object exists and is valid": () => file && helper.isValidCreator(file.creator, data.expectedOwner),
-      "File: creator.id matches expected user": () => file && file.creator && file.creator.id === data.expectedOwner.id,
-      // Note: uid field removed in AIP refactoring - no longer checking creator.uid
+      "File: ownerDisplayName is populated": () => file && typeof file.ownerDisplayName === 'string' && file.ownerDisplayName.length > 0,
+      "File: creatorDisplayName is populated": () => file && typeof file.creatorDisplayName === 'string' && file.creatorDisplayName.length > 0,
+      "File: no embedded owner object (data leakage fix)": () => file && !file.owner,
+      "File: no embedded creator object (data leakage fix)": () => file && !file.creator,
       "File: knowledgeBases is array (or undefined)": () => file && (!file.knowledgeBases || Array.isArray(file.knowledgeBases)),
     });
 
@@ -1706,10 +1707,9 @@ export function TEST_23_OwnerCreatorFields(data) {
 
       check(getFileRes, {
         "Get File: Response status is 200": (r) => r.status === 200,
-        // Note: ownerUid and creatorUid removed in AIP refactoring
         "Get File: ownerName is preserved": () => fetchedFile && fetchedFile.ownerName === `users/${data.expectedOwner.id}`,
-        "Get File: owner object is populated": () => fetchedFile && fetchedFile.owner && fetchedFile.owner.user,
-        "Get File: creator object is populated": () => fetchedFile && fetchedFile.creator && fetchedFile.creator.id === data.expectedOwner.id,
+        "Get File: ownerDisplayName is preserved": () => fetchedFile && typeof fetchedFile.ownerDisplayName === 'string' && fetchedFile.ownerDisplayName.length > 0,
+        "Get File: creatorDisplayName is preserved": () => fetchedFile && typeof fetchedFile.creatorDisplayName === 'string' && fetchedFile.creatorDisplayName.length > 0,
       });
 
       // Verify owner/creator fields persist when listing files
@@ -1726,11 +1726,9 @@ export function TEST_23_OwnerCreatorFields(data) {
       check(listFilesRes, {
         "List Files: Response status is 200": (r) => r.status === 200,
         "List Files: Our file is in the list": () => listedFile !== undefined,
-        // Note: ownerUid and creatorUid removed in AIP refactoring
         "List Files: ownerName is preserved": () => listedFile && listedFile.ownerName === `users/${data.expectedOwner.id}`,
-        "List Files: owner object is populated": () => listedFile && listedFile.owner && listedFile.owner.user,
-        "List Files: owner.user.id matches": () => listedFile && listedFile.owner && listedFile.owner.user && listedFile.owner.user.id === data.expectedOwner.id,
-        "List Files: creator object is populated": () => listedFile && helper.isValidCreator(listedFile.creator, data.expectedOwner),
+        "List Files: ownerDisplayName is preserved": () => listedFile && typeof listedFile.ownerDisplayName === 'string' && listedFile.ownerDisplayName.length > 0,
+        "List Files: creatorDisplayName is preserved": () => listedFile && typeof listedFile.creatorDisplayName === 'string' && listedFile.creatorDisplayName.length > 0,
       });
     }
 

--- a/pkg/handler/converter.go
+++ b/pkg/handler/converter.go
@@ -91,36 +91,74 @@ func convertKBToCatalogPB(kb *repository.KnowledgeBaseModel, ns *resource.Namesp
 	return knowledgeBase
 }
 
+// ownerDisplayInfo extracts display name and avatar from a mgmt Owner (User or Organization).
+func ownerDisplayInfo(owner *mgmtpb.Owner) (displayName string, avatar *string) {
+	if owner == nil {
+		return "", nil
+	}
+	switch o := owner.GetOwner().(type) {
+	case *mgmtpb.Owner_User:
+		if u := o.User; u != nil {
+			displayName = u.GetProfile().GetDisplayName()
+			if a := u.GetProfile().GetAvatar(); a != "" {
+				avatar = &a
+			}
+		}
+	case *mgmtpb.Owner_Organization:
+		if org := o.Organization; org != nil {
+			displayName = org.GetProfile().GetDisplayName()
+			if a := org.GetProfile().GetAvatar(); a != "" {
+				avatar = &a
+			}
+		}
+	}
+	return displayName, avatar
+}
+
+// userDisplayInfo extracts display name and avatar from a mgmt User.
+func userDisplayInfo(user *mgmtpb.User) (displayName string, avatar *string) {
+	if user == nil {
+		return "", nil
+	}
+	displayName = user.GetProfile().GetDisplayName()
+	if a := user.GetProfile().GetAvatar(); a != "" {
+		avatar = &a
+	}
+	return displayName, avatar
+}
+
 // convertKBFileToPB converts database FileModel to protobuf File.
 // The `name` field is computed dynamically following other backends' patterns.
 // The objectID parameter is the hash-based object ID (e.g., "obj-abc123") for AIP-122 compliant resource references.
 func convertKBFileToPB(kbf *repository.FileModel, ns *resource.Namespace, kb *repository.KnowledgeBaseModel, owner *mgmtpb.Owner, creator *mgmtpb.User, objectID string) *artifactpb.File {
-	// ownerName is the full namespace reference (e.g., "users/admin" or "organizations/org-id")
 	ownerName := ns.Name()
-	// namespaceID is just the ID part (e.g., "admin")
 	namespaceID := ns.NsID
-	// Use ID if set, otherwise fallback to UID
 	fileID := kbf.ID
 	if fileID == "" {
 		fileID = kbf.UID.String()
 	}
 
+	ownerDN, ownerAv := ownerDisplayInfo(owner)
+	creatorDN, creatorAv := userDisplayInfo(creator)
+
 	file := &artifactpb.File{
-		Id:               fileID,
-		Slug:             kbf.Slug,                                                                             // URL-friendly slug without prefix
-		Name:             fmt.Sprintf("namespaces/%s/knowledge-bases/%s/files/%s", namespaceID, kb.ID, fileID), // Computed: namespaces/{namespace}/knowledge-bases/{kb}/files/{file}
-		DisplayName:      kbf.DisplayName,
-		Description:      kbf.Description,
-		Type:             convertFileType(kbf.FileType),
-		CreateTime:       timestamppb.New(*kbf.CreateTime),
-		UpdateTime:       timestamppb.New(*kbf.UpdateTime),
-		OwnerName:        ownerName,
-		Owner:            owner,
-		Creator:          creator,
-		KnowledgeBases: []string{fmt.Sprintf("namespaces/%s/knowledge-bases/%s", namespaceID, kb.ID)}, // File associated with this KB
-		Size:             kbf.Size,
-		ProcessStatus:    convertFileProcessStatus(kbf.ProcessStatus),
-		Aliases:          kbf.Aliases,
+		Id:                 fileID,
+		Slug:               kbf.Slug,
+		Name:               fmt.Sprintf("namespaces/%s/knowledge-bases/%s/files/%s", namespaceID, kb.ID, fileID),
+		DisplayName:        kbf.DisplayName,
+		Description:        kbf.Description,
+		Type:               convertFileType(kbf.FileType),
+		CreateTime:         timestamppb.New(*kbf.CreateTime),
+		UpdateTime:         timestamppb.New(*kbf.UpdateTime),
+		OwnerName:          ownerName,
+		OwnerDisplayName:   ownerDN,
+		OwnerAvatar:        ownerAv,
+		CreatorDisplayName: creatorDN,
+		CreatorAvatar:      creatorAv,
+		KnowledgeBases:     []string{fmt.Sprintf("namespaces/%s/knowledge-bases/%s", namespaceID, kb.ID)},
+		Size:               kbf.Size,
+		ProcessStatus:      convertFileProcessStatus(kbf.ProcessStatus),
+		Aliases:            kbf.Aliases,
 	}
 
 	// Handle optional fields

--- a/pkg/handler/file.go
+++ b/pkg/handler/file.go
@@ -638,9 +638,11 @@ func (ph *PublicHandler) CreateFile(ctx context.Context, req *artifactpb.CreateF
 			zap.Bool("hasDualProcessing", dualTarget != nil && dualTarget.IsNeeded))
 	}
 
-	// Fetch owner and creator objects
+	// Fetch owner and creator for denormalized display fields
 	owner, _ := ph.service.FetchOwnerByNamespace(ctx, ns)
 	creator, _ := ph.service.FetchUserByUID(ctx, res.CreatorUID.String())
+	ownerDN, ownerAv := ownerDisplayInfo(owner)
+	creatorDN, creatorAv := userDisplayInfo(creator)
 
 	// Get object ID for AIP-122 compliant resource name
 	objectResourceName := ""
@@ -656,9 +658,11 @@ func (ph *PublicHandler) CreateFile(ctx context.Context, req *artifactpb.CreateF
 			Id:                 res.ID,
 			Slug:               res.Slug,
 			OwnerName:          ns.Name(),
-			Owner:              owner,
-			Creator:            creator,
-			KnowledgeBases:     []string{fmt.Sprintf("namespaces/%s/knowledge-bases/%s", namespaceID, kb.ID)}, // Initial KB association
+			OwnerDisplayName:   ownerDN,
+			OwnerAvatar:        ownerAv,
+			CreatorDisplayName: creatorDN,
+			CreatorAvatar:      creatorAv,
+			KnowledgeBases:     []string{fmt.Sprintf("namespaces/%s/knowledge-bases/%s", namespaceID, kb.ID)},
 			Name:               fmt.Sprintf("namespaces/%s/knowledge-bases/%s/files/%s", namespaceID, kb.ID, res.ID),
 			DisplayName:        res.DisplayName,
 			Type:               req.File.Type,
@@ -847,8 +851,9 @@ func (ph *PublicHandler) ListFiles(ctx context.Context, req *artifactpb.ListFile
 		)
 	}
 
-	// Fetch owner once (same for all files in this KB)
+	// Fetch owner once (same for all files in this KB) and extract denormalized display fields
 	owner, _ := ph.service.FetchOwnerByNamespace(ctx, ns)
+	ownerDN, ownerAv := ownerDisplayInfo(owner)
 
 	// Fetch all file-KB associations for all files in one go if kbID is empty
 	var fileKBAssociations map[types.FileUIDType][]string
@@ -920,8 +925,9 @@ func (ph *PublicHandler) ListFiles(ctx context.Context, req *artifactpb.ListFile
 			downloadURL = response.GetDownloadUrl()
 		}
 
-		// Fetch creator for this file (owner is the same for all files in this KB)
+		// Fetch creator for denormalized display fields (owner is the same for all files in this KB)
 		creator, _ := ph.service.FetchUserByUID(ctx, kbFile.CreatorUID.String())
+		creatorDN, creatorAv := userDisplayInfo(creator)
 
 		// Use ID if set, otherwise fallback to UID (for backward compatibility)
 		fileID := kbFile.ID
@@ -973,8 +979,10 @@ func (ph *PublicHandler) ListFiles(ctx context.Context, req *artifactpb.ListFile
 			Id:                 fileID,
 			Slug:               kbFile.Slug,
 			OwnerName:          ns.Name(),
-			Owner:              owner,
-			Creator:            creator,
+			OwnerDisplayName:   ownerDN,
+			OwnerAvatar:        ownerAv,
+			CreatorDisplayName: creatorDN,
+			CreatorAvatar:      creatorAv,
 			KnowledgeBases:     knowledgeBaseNames,
 			Name:               fmt.Sprintf("namespaces/%s/knowledge-bases/%s/files/%s", namespaceID, fileKBID, fileID),
 			DisplayName:        kbFile.DisplayName,


### PR DESCRIPTION
## Because

- File API responses embedded full `mgmt.Owner` and `mgmt.User` objects, leaking sensitive user metadata (email, profile details) to cross-workspace users and visitors accessing public collections
- The proto fields `owner` (19) and `creator` (21) have been reserved in `file.proto` (PR #726) and replaced with `owner_display_name`, `owner_avatar`, `creator_display_name`, `creator_avatar`

## This commit

- Add `ownerDisplayInfo()` and `userDisplayInfo()` helpers to extract display name and avatar from mgmt Owner/User objects
- Update `convertKBFileToPB` to populate the 4 new denormalized fields
- Update `CreateFile` and `ListFiles` inline structs to use new fields
- Upgrade `protogen-go` to include the updated `file.proto`
- Update k6 integration tests to validate new denormalized fields instead of embedded objects

## Test plan

- [x] `go test ./...` all pass
- [ ] CI integration tests (k6) pass with updated assertions

Made with [Cursor](https://cursor.com)