### PR TITLE
fix(service): add visitor auth support to CheckNamespacePermission

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.1
 	github.com/iancoleman/strcase v0.3.0
 	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20260413222502-4b62bd23229d
-	github.com/instill-ai/x v0.10.1-alpha.0.20260413222128-b9e1a79a9d17
+	github.com/instill-ai/x v0.10.1-alpha.0.20260414224753-def83be2e9e0
 	github.com/knadh/koanf v1.5.0
 	github.com/mennanov/fieldmask-utils v1.1.2
 	github.com/milvus-io/milvus/client/v2 v2.6.3

--- a/go.sum
+++ b/go.sum
@@ -67,6 +67,8 @@ github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuy
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
+github.com/alicebob/miniredis/v2 v2.37.0 h1:RheObYW32G1aiJIj81XVt78ZHJpHonHLHW7OLIshq68=
+github.com/alicebob/miniredis/v2 v2.37.0/go.mod h1:TcL7YfarKPGDAthEtl5NBeHZfeUQj6OXMm/+iu5cLMM=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
@@ -429,8 +431,8 @@ github.com/imkira/go-interpol v1.1.0/go.mod h1:z0h2/2T3XF8kyEPpRgJ3kmNv+C43p+I/C
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20260413222502-4b62bd23229d h1:AV/3TjveDNkbLu6OkkCIjxYyjMuqV2RKpy5qbwU7LFk=
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20260413222502-4b62bd23229d/go.mod h1:bCnBosofpaUxKBuTTJM3/I3thAK37kvfBnKByjnLsl4=
-github.com/instill-ai/x v0.10.1-alpha.0.20260413222128-b9e1a79a9d17 h1:Rz65sly8I4DOY9YMd8RS208oH8RIdyK6n6EkIH3aGbs=
-github.com/instill-ai/x v0.10.1-alpha.0.20260413222128-b9e1a79a9d17/go.mod h1:l66X/UwzzmzCHeZhkjrlxN44IZFMuu2E/k3TeQi+TO8=
+github.com/instill-ai/x v0.10.1-alpha.0.20260414224753-def83be2e9e0 h1:5Rm0ONs+s+ZKS2BuNYoVGxCmElPKNi4nWqcKSmc4opc=
+github.com/instill-ai/x v0.10.1-alpha.0.20260414224753-def83be2e9e0/go.mod h1:r6kGo7M1dkYtzSqetAWT1kpglpVzqOmPc+ADs6obpKs=
 github.com/iris-contrib/blackfriday v2.0.0+incompatible/go.mod h1:UzZ2bDEoaSGPbkg6SAB4att1aAwTmVIx/5gCVqeyUdI=
 github.com/iris-contrib/go.uuid v2.0.0+incompatible/go.mod h1:iz2lgM/1UnEf1kP0L/+fafWORmlnuysV2EMP8MW+qe0=
 github.com/iris-contrib/jade v1.1.3/go.mod h1:H/geBymxJhShH5kecoiOCSssPX7QWYH7UaeZTSWddIk=
@@ -828,6 +830,8 @@ github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9de
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
+github.com/yuin/gopher-lua v1.1.1 h1:kYKnWBjvbNP4XLT3+bPEwAXJx262OhaHDWDVOPjL46M=
+github.com/yuin/gopher-lua v1.1.1/go.mod h1:GBR0iDaNXjAgGg9zfCvksxSRnQx76gclCIb7kdAd1Pw=
 github.com/yusufpapurcu/wmi v1.2.3 h1:E1ctvB7uKFMOJw3fdOW32DwGE9I7t++CRUEMKvFoFiw=
 github.com/yusufpapurcu/wmi v1.2.3/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
 github.com/zeebo/errs v1.4.0 h1:XNdoD/RRMKP7HD0UhJnIzUy74ISdGGxURlYG8HSWSfM=

--- a/pkg/service/utils.go
+++ b/pkg/service/utils.go
@@ -20,17 +20,40 @@ func IsTrustedBackendRequest(ctx context.Context) bool {
 	return resourcex.GetRequestSingleHeader(ctx, "Instill-Backend") != ""
 }
 
-// CheckNamespacePermission checks if the user has permission to access the namespace.
+// CheckNamespacePermission validates that the caller can access resources
+// within the given namespace. This is the namespace-level gate; per-resource
+// access is further controlled by FGA CheckPermission.
+//
+// Access methods (in priority order):
+//
+//  1. Trusted backend (Instill-Backend header) — service-to-service calls.
+//     The calling service already verified permissions at its own level.
+//
+//  2. Visitor (Instill-Auth-Type: visitor) — anonymous users accessing
+//     public resources via capability token. Visitors don't belong to any
+//     namespace; their access is gated entirely by per-resource FGA tuples
+//     (visitor:* reader). The capability token was validated by the API
+//     gateway before these headers were set.
+//
+//  3. User (Instill-Auth-Type: user) — authenticated users. Must be an org
+//     member (for organizations) or the namespace owner (for personal
+//     namespaces).
+//
+// Note: authenticated users accessing OTHER namespaces via capability tokens
+// (cross-workspace share links) are handled by agent-backend-ee's
+// GetCapabilityContext + CheckShareLinkPermission flow. artifact-backend
+// receives these as trusted S2S calls (case 1).
 func (s *service) CheckNamespacePermission(ctx context.Context, ns *resource.Namespace) error {
-	// Trusted backend-to-backend calls (e.g., agent-backend autofill workers)
-	// bypass FGA since the calling service already verified permissions.
 	if IsTrustedBackendRequest(ctx) {
 		return nil
 	}
 
-	// TODO: optimize ACL model
+	authType := resourcex.GetRequestSingleHeader(ctx, constant.HeaderAuthTypeKey)
+	if authType == "visitor" {
+		return nil
+	}
+
 	if ns.NsType == "organizations" {
-		// check if the user is a member of the organization
 		granted, err := s.aclClient.CheckPermission(ctx, "organization", ns.NsUID, "member")
 		if err != nil {
 			return err
@@ -38,7 +61,6 @@ func (s *service) CheckNamespacePermission(ctx context.Context, ns *resource.Nam
 		if !granted {
 			return errorsx.ErrUnauthenticated
 		}
-		// check if the user is the owner of the namespace
 	} else if ns.NsUID != uuid.FromStringOrNil(resourcex.GetRequestSingleHeader(ctx, constant.HeaderUserUIDKey)) {
 		return errorsx.ErrUnauthenticated
 	}

--- a/pkg/service/utils_test.go
+++ b/pkg/service/utils_test.go
@@ -1,0 +1,126 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gofrs/uuid"
+	"google.golang.org/grpc/metadata"
+
+	"github.com/instill-ai/artifact-backend/pkg/resource"
+	"github.com/instill-ai/x/constant"
+)
+
+func ctxWithHeaders(headers map[string]string) context.Context {
+	md := metadata.New(headers)
+	return metadata.NewIncomingContext(context.Background(), md)
+}
+
+// ============================================================
+// IsTrustedBackendRequest
+// ============================================================
+
+func TestIsTrustedBackendRequest_WithHeader(t *testing.T) {
+	ctx := ctxWithHeaders(map[string]string{
+		"Instill-Backend": "agent-backend",
+	})
+	if !IsTrustedBackendRequest(ctx) {
+		t.Error("request with Instill-Backend header should be trusted")
+	}
+}
+
+func TestIsTrustedBackendRequest_WithoutHeader(t *testing.T) {
+	ctx := ctxWithHeaders(map[string]string{})
+	if IsTrustedBackendRequest(ctx) {
+		t.Error("request without Instill-Backend header should not be trusted")
+	}
+}
+
+// ============================================================
+// CheckNamespacePermission — namespace-level access gate
+// ============================================================
+
+func TestCheckNamespacePermission_TrustedBackendBypasses(t *testing.T) {
+	svc := &service{}
+	ctx := ctxWithHeaders(map[string]string{
+		"Instill-Backend": "agent-backend",
+	})
+	ns := &resource.Namespace{NsType: "organizations", NsUID: uuid.Must(uuid.NewV4())}
+
+	err := svc.CheckNamespacePermission(ctx, ns)
+	if err != nil {
+		t.Errorf("trusted backend should bypass namespace permission, got: %v", err)
+	}
+}
+
+func TestCheckNamespacePermission_VisitorBypasses(t *testing.T) {
+	svc := &service{}
+	ctx := ctxWithHeaders(map[string]string{
+		constant.HeaderAuthTypeKey:   "visitor",
+		constant.HeaderVisitorUIDKey: "b6e1f5c3-7a2d-4e89-9f01-abc123def456",
+	})
+	ns := &resource.Namespace{NsType: "organizations", NsUID: uuid.Must(uuid.NewV4())}
+
+	err := svc.CheckNamespacePermission(ctx, ns)
+	if err != nil {
+		t.Errorf("visitor should bypass namespace permission, got: %v", err)
+	}
+}
+
+func TestCheckNamespacePermission_UserInOwnPersonalNamespace(t *testing.T) {
+	userUID := uuid.Must(uuid.FromString("a1b2c3d4-e5f6-7890-abcd-ef1234567890"))
+	svc := &service{}
+	ctx := ctxWithHeaders(map[string]string{
+		constant.HeaderAuthTypeKey: "user",
+		constant.HeaderUserUIDKey:  userUID.String(),
+	})
+	ns := &resource.Namespace{NsType: "users", NsUID: userUID}
+
+	err := svc.CheckNamespacePermission(ctx, ns)
+	if err != nil {
+		t.Errorf("user in own namespace should be allowed, got: %v", err)
+	}
+}
+
+func TestCheckNamespacePermission_UserInOtherPersonalNamespace(t *testing.T) {
+	svc := &service{}
+	ctx := ctxWithHeaders(map[string]string{
+		constant.HeaderAuthTypeKey: "user",
+		constant.HeaderUserUIDKey:  "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+	})
+	otherUserUID := uuid.Must(uuid.FromString("ffffffff-ffff-ffff-ffff-ffffffffffff"))
+	ns := &resource.Namespace{NsType: "users", NsUID: otherUserUID}
+
+	err := svc.CheckNamespacePermission(ctx, ns)
+	if err == nil {
+		t.Fatal("user should not access another user's personal namespace")
+	}
+}
+
+func TestCheckNamespacePermission_VisitorAccessesPersonalNamespace(t *testing.T) {
+	svc := &service{}
+	ctx := ctxWithHeaders(map[string]string{
+		constant.HeaderAuthTypeKey:   "visitor",
+		constant.HeaderVisitorUIDKey: "b6e1f5c3-7a2d-4e89-9f01-abc123def456",
+	})
+	ns := &resource.Namespace{NsType: "users", NsUID: uuid.Must(uuid.NewV4())}
+
+	err := svc.CheckNamespacePermission(ctx, ns)
+	if err != nil {
+		t.Errorf("visitor should bypass even for personal namespaces (FGA is the gate), got: %v", err)
+	}
+}
+
+func TestCheckNamespacePermission_VisitorAccessesOrgNamespace(t *testing.T) {
+	svc := &service{}
+	ctx := ctxWithHeaders(map[string]string{
+		constant.HeaderAuthTypeKey:   "visitor",
+		constant.HeaderVisitorUIDKey: "b6e1f5c3-7a2d-4e89-9f01-abc123def456",
+	})
+	ns := &resource.Namespace{NsType: "organizations", NsUID: uuid.Must(uuid.NewV4())}
+
+	err := svc.CheckNamespacePermission(ctx, ns)
+	if err != nil {
+		t.Errorf("visitor should bypass org namespace check (FGA is the gate), got: %v", err)
+	}
+}


### PR DESCRIPTION
Because

- Visitors are rejected by `CheckNamespacePermission` before reaching per-resource FGA checks, blocking all artifact-backend APIs for anonymous users
- This is the namespace-level gate used by 8 handler call sites (object.go x4, knowledge_base.go x2, file.go x1, permission.go x1)
- Completing the namespace access control model so all access methods (trusted backend, visitor, user) are properly handled

This commit

- Add visitor auth type bypass in `CheckNamespacePermission` — visitors have no namespace membership; their access is gated by per-resource FGA tuples (`visitor:*` reader)
- Add comprehensive doc comment documenting the full access control model (trusted backend, visitor, user, cross-workspace via S2S)
- Add 8 unit tests for `CheckNamespacePermission` and `IsTrustedBackendRequest`
- Bump `x` dependency to pick up visitor bypass in `CheckRequesterPermission` (x#87)