### PR TITLE
feat(file): add visibility field and protobuf wiring

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/grpc-ecosystem/go-grpc-middleware v1.4.0
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.1
 	github.com/iancoleman/strcase v0.3.0
-	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20260413222502-4b62bd23229d
+	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20260416183329-cf0e008d2e76
 	github.com/instill-ai/x v0.10.1-alpha.0.20260414224753-def83be2e9e0
 	github.com/knadh/koanf v1.5.0
 	github.com/mennanov/fieldmask-utils v1.1.2

--- a/go.sum
+++ b/go.sum
@@ -429,8 +429,8 @@ github.com/iancoleman/strcase v0.3.0 h1:nTXanmYxhfFAMjZL34Ov6gkzEsSJZ5DbhxWjvSAS
 github.com/iancoleman/strcase v0.3.0/go.mod h1:iwCmte+B7n89clKwxIoIXy/HfoL7AsD47ZCWhYzw7ho=
 github.com/imkira/go-interpol v1.1.0/go.mod h1:z0h2/2T3XF8kyEPpRgJ3kmNv+C43p+I/CoI+jC3w2iA=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20260413222502-4b62bd23229d h1:AV/3TjveDNkbLu6OkkCIjxYyjMuqV2RKpy5qbwU7LFk=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20260413222502-4b62bd23229d/go.mod h1:bCnBosofpaUxKBuTTJM3/I3thAK37kvfBnKByjnLsl4=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20260416183329-cf0e008d2e76 h1:chY0RSscQH5Dp6YB2gAc2L++T08msS11YnSFahTo1m0=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20260416183329-cf0e008d2e76/go.mod h1:bCnBosofpaUxKBuTTJM3/I3thAK37kvfBnKByjnLsl4=
 github.com/instill-ai/x v0.10.1-alpha.0.20260414224753-def83be2e9e0 h1:5Rm0ONs+s+ZKS2BuNYoVGxCmElPKNi4nWqcKSmc4opc=
 github.com/instill-ai/x v0.10.1-alpha.0.20260414224753-def83be2e9e0/go.mod h1:r6kGo7M1dkYtzSqetAWT1kpglpVzqOmPc+ADs6obpKs=
 github.com/iris-contrib/blackfriday v2.0.0+incompatible/go.mod h1:UzZ2bDEoaSGPbkg6SAB4att1aAwTmVIx/5gCVqeyUdI=

--- a/pkg/db/migration/000068_add_visibility_to_file.down.sql
+++ b/pkg/db/migration/000068_add_visibility_to_file.down.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS idx_file_visibility;
+ALTER TABLE file DROP COLUMN IF EXISTS visibility;

--- a/pkg/db/migration/000068_add_visibility_to_file.up.sql
+++ b/pkg/db/migration/000068_add_visibility_to_file.up.sql
@@ -1,0 +1,13 @@
+-- Add visibility column to the file table so we can model who can discover
+-- and access each file (mirrors collection.visibility). Default to
+-- VISIBILITY_WORKSPACE so existing rows become workspace-visible, matching
+-- today's implicit behaviour where org members can read every file in the
+-- knowledge base.
+ALTER TABLE file
+    ADD COLUMN IF NOT EXISTS visibility VARCHAR(32) NOT NULL DEFAULT 'VISIBILITY_WORKSPACE';
+
+-- Partial index for queries that filter by visibility (e.g. listing
+-- link-shared files) without scanning soft-deleted rows.
+CREATE INDEX IF NOT EXISTS idx_file_visibility
+    ON file (visibility)
+    WHERE delete_time IS NULL;

--- a/pkg/db/migration/migration.go
+++ b/pkg/db/migration/migration.go
@@ -9,7 +9,7 @@ import (
 )
 
 // TargetSchemaVersion determines the database schema version.
-const TargetSchemaVersion uint = 67
+const TargetSchemaVersion uint = 68
 
 type migration interface {
 	Migrate() error

--- a/pkg/handler/converter.go
+++ b/pkg/handler/converter.go
@@ -171,6 +171,7 @@ func convertKBFileToPB(kbf *repository.FileModel, ns *resource.Namespace, kb *re
 		Size:               kbf.Size,
 		ProcessStatus:      convertFileProcessStatus(kbf.ProcessStatus),
 		Aliases:            kbf.Aliases,
+		Visibility:         convertFileVisibility(kbf.Visibility),
 	}
 
 	// Handle optional fields
@@ -227,4 +228,32 @@ func convertFileProcessStatus(status string) artifactpb.FileProcessStatus {
 		// Legacy statuses (WAITING, CONVERTING, SUMMARIZING) return UNSPECIFIED
 		return artifactpb.FileProcessStatus_FILE_PROCESS_STATUS_UNSPECIFIED
 	}
+}
+
+// convertFileVisibility converts the database visibility string to the
+// protobuf enum. Empty or unknown values fall back to VISIBILITY_WORKSPACE,
+// which matches the DB default and ensures legacy rows (created before the
+// visibility column existed) are surfaced as workspace-visible.
+func convertFileVisibility(v string) artifactpb.File_Visibility {
+	if v == "" {
+		return artifactpb.File_VISIBILITY_WORKSPACE
+	}
+	if val, ok := artifactpb.File_Visibility_value[v]; ok {
+		out := artifactpb.File_Visibility(val)
+		if out == artifactpb.File_VISIBILITY_UNSPECIFIED {
+			return artifactpb.File_VISIBILITY_WORKSPACE
+		}
+		return out
+	}
+	return artifactpb.File_VISIBILITY_WORKSPACE
+}
+
+// normalizeFileVisibility maps a requested visibility enum into the string
+// form persisted on FileModel. UNSPECIFIED is treated as WORKSPACE so callers
+// that omit the field get a safe default.
+func normalizeFileVisibility(v artifactpb.File_Visibility) string {
+	if v == artifactpb.File_VISIBILITY_UNSPECIFIED {
+		return artifactpb.File_VISIBILITY_WORKSPACE.String()
+	}
+	return v.String()
 }

--- a/pkg/handler/converter_test.go
+++ b/pkg/handler/converter_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/instill-ai/artifact-backend/pkg/resource"
 	"github.com/instill-ai/artifact-backend/pkg/types"
 
+	artifactpb "github.com/instill-ai/protogen-go/artifact/v1alpha"
 	mgmtpb "github.com/instill-ai/protogen-go/mgmt/v1beta"
 )
 
@@ -174,6 +175,69 @@ func TestConvertKBFileToPB_CreatorName(t *testing.T) {
 		c.Assert(file.Object, qt.Equals, "namespaces/test-ns/objects/obj-hash123")
 		c.Assert(file.Size, qt.Equals, int64(1024))
 	})
+
+	c.Run("Visibility defaults to WORKSPACE when model field is empty", func(c *qt.C) {
+		// Legacy rows created before the visibility column existed will have
+		// an empty string after migration rollback/forward, so the converter
+		// must never surface UNSPECIFIED to the wire.
+		file := convertKBFileToPB(makeFileModel(), ns, kb, nil, nil, "")
+		c.Assert(file.Visibility, qt.Equals, artifactpb.File_VISIBILITY_WORKSPACE)
+	})
+
+	c.Run("Visibility from model is propagated to proto", func(c *qt.C) {
+		m := makeFileModel()
+		m.Visibility = artifactpb.File_VISIBILITY_LINK_SHARED.String()
+		file := convertKBFileToPB(m, ns, kb, nil, nil, "")
+		c.Assert(file.Visibility, qt.Equals, artifactpb.File_VISIBILITY_LINK_SHARED)
+	})
+}
+
+func TestConvertFileVisibility(t *testing.T) {
+	c := qt.New(t)
+
+	testCases := []struct {
+		name  string
+		input string
+		want  artifactpb.File_Visibility
+	}{
+		{"empty falls back to WORKSPACE", "", artifactpb.File_VISIBILITY_WORKSPACE},
+		{"unknown value falls back to WORKSPACE", "VISIBILITY_GARBAGE", artifactpb.File_VISIBILITY_WORKSPACE},
+		{"UNSPECIFIED is normalized to WORKSPACE", "VISIBILITY_UNSPECIFIED", artifactpb.File_VISIBILITY_WORKSPACE},
+		{"PRIVATE", "VISIBILITY_PRIVATE", artifactpb.File_VISIBILITY_PRIVATE},
+		{"PUBLIC", "VISIBILITY_PUBLIC", artifactpb.File_VISIBILITY_PUBLIC},
+		{"WORKSPACE", "VISIBILITY_WORKSPACE", artifactpb.File_VISIBILITY_WORKSPACE},
+		{"LINK_SHARED", "VISIBILITY_LINK_SHARED", artifactpb.File_VISIBILITY_LINK_SHARED},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		c.Run(tc.name, func(c *qt.C) {
+			c.Assert(convertFileVisibility(tc.input), qt.Equals, tc.want)
+		})
+	}
+}
+
+func TestNormalizeFileVisibility(t *testing.T) {
+	c := qt.New(t)
+
+	testCases := []struct {
+		name  string
+		input artifactpb.File_Visibility
+		want  string
+	}{
+		{"UNSPECIFIED maps to WORKSPACE string", artifactpb.File_VISIBILITY_UNSPECIFIED, "VISIBILITY_WORKSPACE"},
+		{"PRIVATE round-trips", artifactpb.File_VISIBILITY_PRIVATE, "VISIBILITY_PRIVATE"},
+		{"PUBLIC round-trips", artifactpb.File_VISIBILITY_PUBLIC, "VISIBILITY_PUBLIC"},
+		{"WORKSPACE round-trips", artifactpb.File_VISIBILITY_WORKSPACE, "VISIBILITY_WORKSPACE"},
+		{"LINK_SHARED round-trips", artifactpb.File_VISIBILITY_LINK_SHARED, "VISIBILITY_LINK_SHARED"},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		c.Run(tc.name, func(c *qt.C) {
+			c.Assert(normalizeFileVisibility(tc.input), qt.Equals, tc.want)
+		})
+	}
 }
 
 func TestExtractCollectionIDs(t *testing.T) {

--- a/pkg/handler/file.go
+++ b/pkg/handler/file.go
@@ -229,6 +229,7 @@ func (ph *PublicHandler) CreateFile(ctx context.Context, req *artifactpb.CreateF
 		ProcessStatus:             artifactpb.FileProcessStatus_FILE_PROCESS_STATUS_NOTSTARTED.String(),
 		ExternalMetadataUnmarshal: md,
 		Tags:                      repository.TagsArray(req.GetFile().GetTags()),
+		Visibility:                normalizeFileVisibility(req.GetFile().GetVisibility()),
 	}
 
 	if req.GetFile().GetConvertingPipeline() != "" {
@@ -680,6 +681,7 @@ func (ph *PublicHandler) CreateFile(ctx context.Context, req *artifactpb.CreateF
 			Tags:               res.Tags,
 			Collections:        extractCollectionIDs(res.Tags),
 			ContentSha256:      res.ContentSHA256,
+			Visibility:         convertFileVisibility(res.Visibility),
 		},
 	}, nil
 }
@@ -1005,6 +1007,7 @@ func (ph *PublicHandler) ListFiles(ctx context.Context, req *artifactpb.ListFile
 			Collections:        extractCollectionIDs(kbFile.Tags),
 			IsTextBased:        kbFile.IsTextBased,
 			ContentSha256:      kbFile.ContentSHA256,
+			Visibility:         convertFileVisibility(kbFile.Visibility),
 		}
 
 		// Include status message (error or success message)

--- a/pkg/handler/private.go
+++ b/pkg/handler/private.go
@@ -678,6 +678,7 @@ func (h *PrivateHandler) ReprocessFileAdmin(ctx context.Context, req *artifactpb
 		ProcessStatus: artifactpb.FileProcessStatus(artifactpb.FileProcessStatus_value[updatedFile.ProcessStatus]),
 		Size:          updatedFile.Size,
 		ContentSha256: updatedFile.ContentSHA256,
+		Visibility:    convertFileVisibility(updatedFile.Visibility),
 	}
 	if updatedFile.CreateTime != nil {
 		pbFile.CreateTime = timestamppb.New(*updatedFile.CreateTime)

--- a/pkg/repository/create_file_admin_test.go
+++ b/pkg/repository/create_file_admin_test.go
@@ -49,7 +49,8 @@ func setupTestDB(t *testing.T) *gorm.DB {
 			tags TEXT,
 			usage_metadata TEXT,
 			content_sha256 TEXT,
-			is_text_based BOOLEAN DEFAULT FALSE
+			is_text_based BOOLEAN DEFAULT FALSE,
+			visibility TEXT NOT NULL DEFAULT 'VISIBILITY_WORKSPACE'
 		)`,
 		`CREATE TABLE file_knowledge_base (
 			file_uid TEXT NOT NULL,

--- a/pkg/repository/file.go
+++ b/pkg/repository/file.go
@@ -179,6 +179,11 @@ type FileModel struct {
 	// Whether the document has a native text layer (true) or is image-based/scanned (false).
 	// Determined during file processing. Only meaningful for document types (PDF, DOCX, etc.).
 	IsTextBased bool `gorm:"column:is_text_based;default:false" json:"is_text_based"`
+	// Visibility controls who can discover and access the file. Stored as the
+	// string form of the artifactpb.File_Visibility enum (e.g.
+	// "VISIBILITY_WORKSPACE", "VISIBILITY_LINK_SHARED"). Defaults to
+	// VISIBILITY_WORKSPACE so org members can access the file.
+	Visibility string `gorm:"column:visibility;not null;default:VISIBILITY_WORKSPACE" json:"visibility"`
 }
 
 // TableName overrides the default table name for GORM
@@ -257,6 +262,7 @@ type FileColumns struct {
 	ExternalMetadata string
 	Tags             string
 	UsageMetadata    string
+	Visibility       string
 }
 
 // FileColumn is the columns for the file table
@@ -280,6 +286,7 @@ var FileColumn = FileColumns{
 	ExternalMetadata: "external_metadata",
 	Tags:             "tags",
 	UsageMetadata:    "usage_metadata",
+	Visibility:       "visibility",
 }
 
 // ConvertingPipeline extracts the conversion pipeline, if present, from the


### PR DESCRIPTION
Because

- Share Link Foundation needs a first-class `visibility` on each file so we can model who can discover and access it, mirroring the existing `Collection.visibility` model
- Today every file is implicitly workspace-readable via the parent knowledge base's FGA grants; we need an explicit column before we can introduce link-shared files in follow-up PRs
- Without this field, protogen-go's new `File.Visibility` enum is dead weight and the upcoming `artifact-backend-ee` schema migration (000068) has nothing to power

This commit

- Bumps `protogen-go` to pick up the new `File.Visibility` enum (`UNSPECIFIED`, `PRIVATE`, `PUBLIC`, `WORKSPACE`, `LINK_SHARED`)
- Adds a `Visibility string` column to `FileModel` (stored as the enum string, defaulting to `VISIBILITY_WORKSPACE`) and exposes it through `FileColumn`
- Threads `req.File.Visibility` into the `CreateFile` path so new files persist the caller-supplied visibility
- Sets `Visibility` on all four `*artifactpb.File` constructions: `convertKBFileToPB`, the inline `CreateFileResponse` and `GetFile/ListFiles` builders in `pkg/handler/file.go`, and the admin `ReprocessFileAdmin` response in `pkg/handler/private.go`
- Introduces `convertFileVisibility` (DB string -> PB enum) and `normalizeFileVisibility` (PB enum -> DB string) with `UNSPECIFIED`/unknown/empty -> `WORKSPACE` fallback so legacy rows and clients that omit the field stay workspace-visible
- Adds unit tests covering both helpers (12 cases) plus two subtests in `TestConvertKBFileToPB_CreatorName` that verify empty and non-empty model visibility round-trip through the converter