### PR TITLE
fix(acl): adapt ListPermissions wrapper to x v0.10.1-alpha (post-#89/#90)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.1
 	github.com/iancoleman/strcase v0.3.0
 	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20260418224708-f649f82eba2e
-	github.com/instill-ai/x v0.10.1-alpha.0.20260414224753-def83be2e9e0
+	github.com/instill-ai/x v0.10.1-alpha.0.20260421042756-62bca0a82d18
 	github.com/knadh/koanf v1.5.0
 	github.com/mennanov/fieldmask-utils v1.1.2
 	github.com/milvus-io/milvus/client/v2 v2.6.3

--- a/go.sum
+++ b/go.sum
@@ -431,8 +431,8 @@ github.com/imkira/go-interpol v1.1.0/go.mod h1:z0h2/2T3XF8kyEPpRgJ3kmNv+C43p+I/C
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20260418224708-f649f82eba2e h1:Pm4vag7SS6DywS4rFGKrqDwnQruLsGVksKFw6smBMPs=
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20260418224708-f649f82eba2e/go.mod h1:bCnBosofpaUxKBuTTJM3/I3thAK37kvfBnKByjnLsl4=
-github.com/instill-ai/x v0.10.1-alpha.0.20260414224753-def83be2e9e0 h1:5Rm0ONs+s+ZKS2BuNYoVGxCmElPKNi4nWqcKSmc4opc=
-github.com/instill-ai/x v0.10.1-alpha.0.20260414224753-def83be2e9e0/go.mod h1:r6kGo7M1dkYtzSqetAWT1kpglpVzqOmPc+ADs6obpKs=
+github.com/instill-ai/x v0.10.1-alpha.0.20260421042756-62bca0a82d18 h1:AyE9cUxOvCGYWoe/kmroALOBY9J0bT3gfavoTvU02DY=
+github.com/instill-ai/x v0.10.1-alpha.0.20260421042756-62bca0a82d18/go.mod h1:r6kGo7M1dkYtzSqetAWT1kpglpVzqOmPc+ADs6obpKs=
 github.com/iris-contrib/blackfriday v2.0.0+incompatible/go.mod h1:UzZ2bDEoaSGPbkg6SAB4att1aAwTmVIx/5gCVqeyUdI=
 github.com/iris-contrib/go.uuid v2.0.0+incompatible/go.mod h1:iz2lgM/1UnEf1kP0L/+fafWORmlnuysV2EMP8MW+qe0=
 github.com/iris-contrib/jade v1.1.3/go.mod h1:H/geBymxJhShH5kecoiOCSssPX7QWYH7UaeZTSWddIk=

--- a/pkg/acl/acl.go
+++ b/pkg/acl/acl.go
@@ -128,8 +128,23 @@ func (c *ACLClient) GetOwner(ctx context.Context, objectType string, objectUID u
 }
 
 // Legacy alias for backward compatibility.
+//
+// The upstream `x.ACLClient.ListPermissions` signature was split into two
+// functions in x@v0.10.1-alpha.0.20260420155055 (PR instill-ai/x#89):
+//   - `ListPermissions(ctx, objectType, role)` - permissions for the
+//     authenticated requester resolved from ctx headers.
+//   - `ListPublicPermissions(ctx, objectType, role)` - permissions granted
+//     to the `user:*` wildcard (public collections).
+//
+// This wrapper preserves the old 4-argument signature so existing callers in
+// both artifact-backend and artifact-backend-ee keep compiling, and dispatches
+// to the correct new function based on `isPublic`. New callers should prefer
+// invoking the x client methods directly.
 func (c *ACLClient) ListPermissions(ctx context.Context, objectType string, role string, isPublic bool) ([]uuid.UUID, error) {
-	return c.ACLClient.ListPermissions(ctx, objectType, role, isPublic)
+	if isPublic {
+		return c.ListPublicPermissions(ctx, objectType, role)
+	}
+	return c.ACLClient.ListPermissions(ctx, objectType, role)
 }
 
 // FormatOwnerPermissionsPrefix returns a helper for owner permission formatting.


### PR DESCRIPTION
## Because

- instill-ai/x#89 split the four-argument `ListPermissions(ctx, objectType, role, isPublic bool)` into two single-purpose functions: `ListPermissions(ctx, objectType, role)` for the authenticated requester resolved from ctx headers, and `ListPublicPermissions(ctx, objectType, role)` for tuples granted to the `user:*` wildcard. The old `isPublic` boolean conflated "list as me" with "list as anyone" in one signature and silently masked unauthenticated requests as public.
- instill-ai/x#90 then collapsed the FGA `capability` subject into `visitor` and added `CheckPermissionWithShareLink`, both required by the upcoming linked-file download fix that consumes this package's `ACLClient`.
- artifact-backend is a downstream consumer of x and still calls the legacy four-argument signature in its own callers, so bumping the x dependency without an adapter would break the build.

## This commit

- Bump `github.com/instill-ai/x` to `v0.10.1-alpha.0.20260421042756-62bca0a82d18` (post #89 + #90).
- Keep the legacy `ACLClient.ListPermissions(ctx, objectType, role, isPublic bool)` signature in `pkg/acl/acl.go` as a thin wrapper that dispatches to either `x.ACLClient.ListPublicPermissions` or `x.ACLClient.ListPermissions` based on `isPublic`. New call sites should prefer the x methods directly.


Made with [Cursor](https://cursor.com)