### PR TITLE
chore(deps): bump x to pick up ListPermissions Redis cache

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.1
 	github.com/iancoleman/strcase v0.3.0
 	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20260422012622-71a3d3f896d9
-	github.com/instill-ai/x v0.10.1-alpha.0.20260421042756-62bca0a82d18
+	github.com/instill-ai/x v0.10.1-alpha.0.20260422142215-00079e97df27
 	github.com/knadh/koanf v1.5.0
 	github.com/mennanov/fieldmask-utils v1.1.2
 	github.com/milvus-io/milvus/client/v2 v2.6.3

--- a/go.sum
+++ b/go.sum
@@ -431,8 +431,8 @@ github.com/imkira/go-interpol v1.1.0/go.mod h1:z0h2/2T3XF8kyEPpRgJ3kmNv+C43p+I/C
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20260422012622-71a3d3f896d9 h1:jSrPYt01/Kz5wDT2psZkHoGhmpdlcFKeEeywWbelg+Y=
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20260422012622-71a3d3f896d9/go.mod h1:bCnBosofpaUxKBuTTJM3/I3thAK37kvfBnKByjnLsl4=
-github.com/instill-ai/x v0.10.1-alpha.0.20260421042756-62bca0a82d18 h1:AyE9cUxOvCGYWoe/kmroALOBY9J0bT3gfavoTvU02DY=
-github.com/instill-ai/x v0.10.1-alpha.0.20260421042756-62bca0a82d18/go.mod h1:r6kGo7M1dkYtzSqetAWT1kpglpVzqOmPc+ADs6obpKs=
+github.com/instill-ai/x v0.10.1-alpha.0.20260422142215-00079e97df27 h1:xHOMF9FL2Oda5sCzfVT6iztvUw4fQc4eKZ87Xyd42SA=
+github.com/instill-ai/x v0.10.1-alpha.0.20260422142215-00079e97df27/go.mod h1:r6kGo7M1dkYtzSqetAWT1kpglpVzqOmPc+ADs6obpKs=
 github.com/iris-contrib/blackfriday v2.0.0+incompatible/go.mod h1:UzZ2bDEoaSGPbkg6SAB4att1aAwTmVIx/5gCVqeyUdI=
 github.com/iris-contrib/go.uuid v2.0.0+incompatible/go.mod h1:iz2lgM/1UnEf1kP0L/+fafWORmlnuysV2EMP8MW+qe0=
 github.com/iris-contrib/jade v1.1.3/go.mod h1:H/geBymxJhShH5kecoiOCSssPX7QWYH7UaeZTSWddIk=


### PR DESCRIPTION
## Because

- `ListPermissions` (FGA `StreamedListObjects`) is the primary bottleneck for `ListFiles` latency (~3.6s per request scanning all FGA tuples)
- The `instill-ai/x` PR #91 added a Redis cache (60s TTL) with broadcast invalidation, reducing repeated calls from seconds to sub-millisecond

## This commit

- Bump `github.com/instill-ai/x` from `62bca0a` to `00079e9` to pick up the new `ListPermissions` / `ListPublicPermissions` Redis cache

Made with [Cursor](https://cursor.com)