### PR TITLE
feat(repo,handler): add FilePermissionFilter for push-down per-row authorization

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,6 +117,20 @@ the EE-side authoring conventions.
 
 ## Invariants
 
+- **ARTIFACT-INV-LIST-FILES-PERMISSION-FILTER.** `PublicHandler.ListFiles`
+  delegates to `PublicHandler.ListFilesWithPermissionFilter(ctx, req, nil)`
+  — the latter is the actual implementation and the supported extension
+  point for callers (notably `artifact-backend-ee`) that need per-row
+  authorization in addition to namespace / KB ACL. The supplied
+  `*repository.FilePermissionFilter` is compiled into the same SQL `WHERE`
+  as namespace / KB / AIP-160 filters, which keeps `total_size` /
+  `next_page_token` accurate under filtering — a post-pagination filter
+  cannot achieve this and must not be reintroduced. The filter API is
+  intentionally generic (`TagsOverlap` / `UIDsIn` / `TagsLikeNone` /
+  `VisibilityIn` over opaque strings and UUIDs); the repository / handler
+  have zero semantic understanding of any tag value, which keeps EE
+  authorization concepts (collections, FGA, etc.) out of the OSS surface.
+
 - **ARTIFACT-INV-LIST-VIEW-FANOUT.** `PublicHandler.ListFiles` fans out
   per-row presigns through the shared `resolveDerivedResourceURI` helper
   (same code path as `GetFile`) via an `errgroup` with **bounded

--- a/pkg/handler/file.go
+++ b/pkg/handler/file.go
@@ -687,9 +687,31 @@ func (ph *PublicHandler) CreateFile(ctx context.Context, req *artifactpb.CreateF
 	}, nil
 }
 
-// ListFiles lists files in a knowledge base with pagination and filtering (AIP-compliant version of ListKnowledgeBaseFiles).
-// Supports filtering by file IDs and process status, with token/chunk count enrichment.
+// ListFiles lists files in a knowledge base with pagination and filtering
+// (AIP-compliant version of ListKnowledgeBaseFiles). Supports filtering by
+// file IDs and process status, with token/chunk count enrichment.
+//
+// This is the standard CE entry point — it lists every file the surrounding
+// namespace / KB ACL grants the caller access to, with no per-row permission
+// filtering. Enterprise callers that need per-row authorization (e.g.
+// fine-grained file-level FGA grants on top of the namespace check) should
+// call ListFilesWithPermissionFilter directly with a pre-built filter.
 func (ph *PublicHandler) ListFiles(ctx context.Context, req *artifactpb.ListFilesRequest) (*artifactpb.ListFilesResponse, error) {
+	return ph.ListFilesWithPermissionFilter(ctx, req, nil)
+}
+
+// ListFilesWithPermissionFilter is the same as ListFiles but lets the caller
+// inject an optional permission filter that is compiled into the same SQL as
+// pagination. This keeps `total_size` / `next_page_token` correct under
+// per-row authorization, which a post-pagination filter (e.g. filtering
+// returned rows in handler code) cannot achieve.
+//
+// The filter is opaque to this handler and to CE in general: it only deals
+// in tag overlaps, UID lists, tag-prefix-absence, and visibility values. The
+// caller is responsible for translating whatever authorization model it uses
+// into the supplied predicate dimensions. Pass nil to skip permission
+// filtering entirely (this is what the regular ListFiles does).
+func (ph *PublicHandler) ListFilesWithPermissionFilter(ctx context.Context, req *artifactpb.ListFilesRequest, permissionFilter *repository.FilePermissionFilter) (*artifactpb.ListFilesResponse, error) {
 	logger, _ := logx.GetZapLogger(ctx)
 	authUID, err := getUserUIDFromContext(ctx)
 	if err != nil {
@@ -809,11 +831,12 @@ func (ph *PublicHandler) ListFiles(ctx context.Context, req *artifactpb.ListFile
 	}
 
 	kbFileList, err := ph.service.Repository().ListFiles(ctx, repository.KnowledgeBaseFileListParams{
-		OwnerUID:  ns.NsUID.String(),
-		KBUID:     kbUID,
-		PageSize:  int(req.GetPageSize()),
-		PageToken: req.GetPageToken(),
-		Filter:    parsedFilter,
+		OwnerUID:         ns.NsUID.String(),
+		KBUID:            kbUID,
+		PageSize:         int(req.GetPageSize()),
+		PageToken:        req.GetPageToken(),
+		Filter:           parsedFilter,
+		PermissionFilter: permissionFilter,
 	})
 	if err != nil {
 		return nil, errorsx.AddMessage(

--- a/pkg/repository/file.go
+++ b/pkg/repository/file.go
@@ -570,6 +570,138 @@ type KnowledgeBaseFileListParams struct {
 	// Pagination
 	PageSize  int
 	PageToken string
+
+	// PermissionFilter optionally narrows the result to a caller-allowed set.
+	// When nil (or with no clauses), no permission filtering is applied — this
+	// is the CE default. Enterprise callers can supply this to push their
+	// authorization decision into the same SQL as pagination, which keeps
+	// `TotalCount` and `NextPageToken` correct under filtering.
+	//
+	// The repository has no semantic understanding of any tag value, UID, or
+	// LIKE pattern carried in the filter — they are opaque to this package.
+	PermissionFilter *FilePermissionFilter
+}
+
+// FilePermissionFilter narrows a file query to a caller-allowed set.
+//
+// The filter is a disjunction of clauses (`Clauses[i] OR Clauses[j] OR …`).
+// Within a single clause every populated dimension must hold (`AND`). An
+// empty filter or one with no clauses is a no-op and matches every row that
+// the surrounding query already selects.
+//
+// The repository compiles this struct directly into the SQL `WHERE` clause
+// alongside the existing namespace / KB / AIP-160 filter, so pagination
+// remains correct: `TotalCount` reflects the post-filter count, and
+// `NextPageToken` walks the post-filter result set.
+type FilePermissionFilter struct {
+	Clauses []FilePermissionClause
+}
+
+// FilePermissionClause is a single conjunction of dimensions that must all
+// hold for a file to be included by this clause. Each dimension is optional;
+// a clause with no populated dimensions matches every row (use sparingly —
+// effectively disables permission filtering for the query).
+type FilePermissionClause struct {
+	// TagsOverlap matches files whose `tags` array shares at least one element
+	// with the supplied set. Compiles to `file.tags && $1` (PostgreSQL array
+	// overlap operator). Empty slice = dimension not applied.
+	TagsOverlap []string
+
+	// UIDsIn matches files whose primary UID is in the supplied set. Compiles
+	// to `file.uid = ANY($1)`. Empty slice = dimension not applied.
+	UIDsIn []uuid.UUID
+
+	// TagsLikeNone matches files where no element of `tags` matches any of
+	// the supplied SQL `LIKE` patterns. Each pattern compiles to a
+	// `NOT EXISTS (SELECT 1 FROM unnest(file.tags) t WHERE t LIKE $1)`. Used
+	// to express "this file has no tag of shape X" (e.g. orphan-of-some-prefix
+	// reads). Empty slice = dimension not applied.
+	TagsLikeNone []string
+
+	// VisibilityIn matches files whose `visibility` column is in the supplied
+	// set. Compiles to `file.visibility = ANY($1)`. Empty slice = dimension
+	// not applied.
+	VisibilityIn []string
+}
+
+// isEmpty reports whether the clause would not constrain the query at all.
+// A clause with no populated dimensions is excluded from the compiled WHERE
+// (otherwise the disjunction would be `WHERE … OR TRUE` and silently match
+// every row, which is almost certainly not what the caller wanted).
+func (c FilePermissionClause) isEmpty() bool {
+	return len(c.TagsOverlap) == 0 &&
+		len(c.UIDsIn) == 0 &&
+		len(c.TagsLikeNone) == 0 &&
+		len(c.VisibilityIn) == 0
+}
+
+// compile builds the WHERE fragment + ordered bind args for one clause. The
+// returned fragment is wrapped in parentheses so it composes correctly inside
+// the disjunction. Returns ("", nil) for an empty clause; callers must drop
+// such clauses before composing the OR.
+func (c FilePermissionClause) compile() (string, []any) {
+	if c.isEmpty() {
+		return "", nil
+	}
+
+	var preds []string
+	var args []any
+
+	if len(c.TagsOverlap) > 0 {
+		preds = append(preds, "file.tags && ?")
+		args = append(args, pq.Array(c.TagsOverlap))
+	}
+	if len(c.UIDsIn) > 0 {
+		uidStrs := make([]string, len(c.UIDsIn))
+		for i, u := range c.UIDsIn {
+			uidStrs[i] = u.String()
+		}
+		preds = append(preds, "file.uid = ANY(?)")
+		args = append(args, pq.Array(uidStrs))
+	}
+	for _, pattern := range c.TagsLikeNone {
+		// One NOT EXISTS per pattern keeps the predicate index-friendly and
+		// avoids an unnest()-with-OR shape that PG would not be able to
+		// short-circuit cleanly.
+		preds = append(preds, "NOT EXISTS (SELECT 1 FROM unnest(file.tags) t WHERE t LIKE ?)")
+		args = append(args, pattern)
+	}
+	if len(c.VisibilityIn) > 0 {
+		preds = append(preds, "file.visibility = ANY(?)")
+		args = append(args, pq.Array(c.VisibilityIn))
+	}
+
+	return "(" + strings.Join(preds, " AND ") + ")", args
+}
+
+// compile builds the WHERE fragment + ordered bind args for the whole filter.
+// Clauses are joined with OR. Returns ("", nil) when there is nothing to
+// constrain (nil filter, empty Clauses, or every clause empty) so the caller
+// can skip adding a no-op WHERE term.
+func (f *FilePermissionFilter) compile() (string, []any) {
+	if f == nil || len(f.Clauses) == 0 {
+		return "", nil
+	}
+
+	var fragments []string
+	var args []any
+	for _, clause := range f.Clauses {
+		frag, clauseArgs := clause.compile()
+		if frag == "" {
+			continue
+		}
+		fragments = append(fragments, frag)
+		args = append(args, clauseArgs...)
+	}
+
+	if len(fragments) == 0 {
+		return "", nil
+	}
+
+	// A single clause is wrapped in parentheses by clause.compile(); joining
+	// multiple with OR is also wrapped so the term composes safely with
+	// surrounding `AND`s.
+	return "(" + strings.Join(fragments, " OR ") + ")", args
 }
 
 // FileList contains a list of files.
@@ -609,6 +741,14 @@ func (r *repository) ListFiles(ctx context.Context, params KnowledgeBaseFileList
 	if expr != nil {
 		// Apply the filter expression directly using Where with SQL and Vars
 		q = q.Where(expr.SQL, expr.Vars...)
+	}
+
+	// Apply caller-supplied permission filter, if any. Compiled into the same
+	// WHERE clause as namespace / KB / AIP-160 filters so pagination and
+	// `TotalCount` reflect the post-filter result set. Nil or no-op filters
+	// produce an empty fragment and leave the query unchanged.
+	if pfFrag, pfArgs := params.PermissionFilter.compile(); pfFrag != "" {
+		q = q.Where(pfFrag, pfArgs...)
 	}
 
 	// Count the total number of matching records

--- a/pkg/repository/file_permission_filter_test.go
+++ b/pkg/repository/file_permission_filter_test.go
@@ -1,0 +1,192 @@
+package repository
+
+import (
+	"testing"
+
+	"github.com/gofrs/uuid"
+	qt "github.com/frankban/quicktest"
+	"github.com/lib/pq"
+)
+
+// All tests target the SQL-fragment + bind-args contract that
+// repository.ListFiles relies on. They never touch a database — the goal is
+// to lock the compiled output so EE callers (and any future consumers) can
+// reason about exactly what they get when they assemble a permission filter.
+
+func TestFilePermissionClause_compile_empty(t *testing.T) {
+	c := qt.New(t)
+
+	clause := FilePermissionClause{}
+	frag, args := clause.compile()
+
+	c.Check(frag, qt.Equals, "")
+	c.Check(args, qt.IsNil)
+	c.Check(clause.isEmpty(), qt.IsTrue)
+}
+
+func TestFilePermissionClause_compile_tagsOverlap(t *testing.T) {
+	c := qt.New(t)
+
+	tags := []string{"agent:collection:abc", "agent:collection:def"}
+	clause := FilePermissionClause{TagsOverlap: tags}
+	frag, args := clause.compile()
+
+	c.Check(frag, qt.Equals, "(file.tags && ?)")
+	c.Assert(args, qt.HasLen, 1)
+	// pq.Array wraps the slice; equality via reflect.DeepEqual on the wrapper.
+	c.Check(args[0], qt.DeepEquals, pq.Array(tags))
+}
+
+func TestFilePermissionClause_compile_uidsIn(t *testing.T) {
+	c := qt.New(t)
+
+	u1 := uuid.Must(uuid.NewV4())
+	u2 := uuid.Must(uuid.NewV4())
+	clause := FilePermissionClause{UIDsIn: []uuid.UUID{u1, u2}}
+	frag, args := clause.compile()
+
+	c.Check(frag, qt.Equals, "(file.uid = ANY(?))")
+	c.Assert(args, qt.HasLen, 1)
+	c.Check(args[0], qt.DeepEquals, pq.Array([]string{u1.String(), u2.String()}))
+}
+
+func TestFilePermissionClause_compile_tagsLikeNone(t *testing.T) {
+	c := qt.New(t)
+
+	clause := FilePermissionClause{TagsLikeNone: []string{"agent:collection:%", "agent:project:%"}}
+	frag, args := clause.compile()
+
+	// One NOT EXISTS per pattern, AND-joined inside the clause parens.
+	c.Check(frag, qt.Equals,
+		"(NOT EXISTS (SELECT 1 FROM unnest(file.tags) t WHERE t LIKE ?) "+
+			"AND NOT EXISTS (SELECT 1 FROM unnest(file.tags) t WHERE t LIKE ?))")
+	c.Check(args, qt.DeepEquals, []any{"agent:collection:%", "agent:project:%"})
+}
+
+func TestFilePermissionClause_compile_visibilityIn(t *testing.T) {
+	c := qt.New(t)
+
+	clause := FilePermissionClause{VisibilityIn: []string{"VISIBILITY_WORKSPACE", "VISIBILITY_PUBLIC"}}
+	frag, args := clause.compile()
+
+	c.Check(frag, qt.Equals, "(file.visibility = ANY(?))")
+	c.Assert(args, qt.HasLen, 1)
+	c.Check(args[0], qt.DeepEquals, pq.Array([]string{"VISIBILITY_WORKSPACE", "VISIBILITY_PUBLIC"}))
+}
+
+func TestFilePermissionClause_compile_orphanShape(t *testing.T) {
+	// Mirrors the EE "orphan reads" clause: file has no agent:collection: tag
+	// AND visibility is in WORKSPACE. Locks the AND-composition order so the
+	// EE side can rely on a stable plan shape.
+	c := qt.New(t)
+
+	clause := FilePermissionClause{
+		TagsLikeNone: []string{"agent:collection:%"},
+		VisibilityIn: []string{"VISIBILITY_WORKSPACE"},
+	}
+	frag, args := clause.compile()
+
+	c.Check(frag, qt.Equals,
+		"(NOT EXISTS (SELECT 1 FROM unnest(file.tags) t WHERE t LIKE ?) "+
+			"AND file.visibility = ANY(?))")
+	c.Assert(args, qt.HasLen, 2)
+	c.Check(args[0], qt.Equals, "agent:collection:%")
+	c.Check(args[1], qt.DeepEquals, pq.Array([]string{"VISIBILITY_WORKSPACE"}))
+}
+
+func TestFilePermissionFilter_compile_nil(t *testing.T) {
+	c := qt.New(t)
+
+	var f *FilePermissionFilter
+	frag, args := f.compile()
+
+	c.Check(frag, qt.Equals, "")
+	c.Check(args, qt.IsNil)
+}
+
+func TestFilePermissionFilter_compile_emptyClauses(t *testing.T) {
+	c := qt.New(t)
+
+	f := &FilePermissionFilter{}
+	frag, args := f.compile()
+
+	c.Check(frag, qt.Equals, "")
+	c.Check(args, qt.IsNil)
+}
+
+func TestFilePermissionFilter_compile_dropsEmptyClauses(t *testing.T) {
+	// A clause with zero populated dimensions must NOT compile to TRUE — that
+	// would silently widen the disjunction to match every row. Empty clauses
+	// are dropped; if the whole filter ends up empty we return an empty
+	// fragment (no-op).
+	c := qt.New(t)
+
+	f := &FilePermissionFilter{Clauses: []FilePermissionClause{{}, {}}}
+	frag, args := f.compile()
+
+	c.Check(frag, qt.Equals, "")
+	c.Check(args, qt.IsNil)
+}
+
+func TestFilePermissionFilter_compile_singleClauseWrapping(t *testing.T) {
+	c := qt.New(t)
+
+	f := &FilePermissionFilter{
+		Clauses: []FilePermissionClause{{TagsOverlap: []string{"x"}}},
+	}
+	frag, args := f.compile()
+
+	// Outer parens are added even with one clause so the term composes safely
+	// inside an AND-chain in the surrounding query.
+	c.Check(frag, qt.Equals, "((file.tags && ?))")
+	c.Assert(args, qt.HasLen, 1)
+}
+
+func TestFilePermissionFilter_compile_threePathOR(t *testing.T) {
+	// The canonical EE shape: cascade (TagsOverlap), direct (UIDsIn), orphan
+	// (TagsLikeNone + VisibilityIn). Ordering and parenthesisation are part of
+	// the contract — EE relies on the OR composition for correctness.
+	c := qt.New(t)
+
+	cascadeTags := []string{"agent:collection:c1", "agent:collection:c2"}
+	u1 := uuid.Must(uuid.NewV4())
+
+	f := &FilePermissionFilter{
+		Clauses: []FilePermissionClause{
+			{TagsOverlap: cascadeTags},
+			{UIDsIn: []uuid.UUID{u1}},
+			{TagsLikeNone: []string{"agent:collection:%"}, VisibilityIn: []string{"VISIBILITY_WORKSPACE"}},
+		},
+	}
+	frag, args := f.compile()
+
+	c.Check(frag, qt.Equals,
+		"((file.tags && ?) "+
+			"OR (file.uid = ANY(?)) "+
+			"OR (NOT EXISTS (SELECT 1 FROM unnest(file.tags) t WHERE t LIKE ?) "+
+			"AND file.visibility = ANY(?)))")
+
+	c.Assert(args, qt.HasLen, 4)
+	c.Check(args[0], qt.DeepEquals, pq.Array(cascadeTags))
+	c.Check(args[1], qt.DeepEquals, pq.Array([]string{u1.String()}))
+	c.Check(args[2], qt.Equals, "agent:collection:%")
+	c.Check(args[3], qt.DeepEquals, pq.Array([]string{"VISIBILITY_WORKSPACE"}))
+}
+
+func TestFilePermissionFilter_compile_mixedEmptyAndPopulated(t *testing.T) {
+	// Empty clauses interleaved with populated ones must be silently dropped,
+	// not turn the OR into a no-op.
+	c := qt.New(t)
+
+	f := &FilePermissionFilter{
+		Clauses: []FilePermissionClause{
+			{},
+			{TagsOverlap: []string{"agent:collection:c1"}},
+			{},
+		},
+	}
+	frag, args := f.compile()
+
+	c.Check(frag, qt.Equals, "((file.tags && ?))")
+	c.Assert(args, qt.HasLen, 1)
+}


### PR DESCRIPTION
## Because

- `repository.ListFiles` and `PublicHandler.ListFiles` today expose only the namespace + KB ACL boundary; there is no extension point for callers that need to layer additional per-row authorization on top of those checks.
- A common workaround — letting the caller fetch a page from `ListFiles` and then drop rows in application code — is structurally incorrect: `total_size` and `next_page_token` reflect the **pre-filter** result set, so paginating through filtered results silently skips rows and reports the wrong total.
- The only way to keep pagination accurate under per-row authorization is to push the filter into the same SQL as `LIMIT` / `OFFSET`. The repository should expose that capability behind a generic, opaque API so the OSS surface stays free of any specific authorization model.

## This commit

- Add `FilePermissionFilter` and `FilePermissionClause` to `pkg/repository/file.go`. The filter is a disjunction of clauses; each clause AND-composes optional dimensions:
  - `TagsOverlap []string` — \`file.tags && \$1\` (PG array overlap operator)
  - `UIDsIn []uuid.UUID` — \`file.uid = ANY(\$1)\`
  - `TagsLikeNone []string` — per-pattern \`NOT EXISTS (SELECT 1 FROM unnest(file.tags) t WHERE t LIKE \$1)\`
  - `VisibilityIn []string` — \`file.visibility = ANY(\$1)\`
- Add `KnowledgeBaseFileListParams.PermissionFilter` and wire it through `repository.ListFiles`. Nil or empty filter is a no-op so existing in-tree callers see no behaviour change.
- Add `PublicHandler.ListFilesWithPermissionFilter(ctx, req, *FilePermissionFilter)` as the supported handler entry point for callers that need per-row authorization. `PublicHandler.ListFiles` becomes a one-line wrapper that passes `nil` — default behaviour is preserved.
- The filter primitives are intentionally generic and opaque. The repository and handler have **zero semantic understanding** of any tag value, UID, or LIKE pattern carried in the filter. Callers translate whatever authorization model they use into the supplied predicate dimensions; the OSS surface knows only about table columns (`tags`, `uid`, `visibility`).
- Unit tests (`pkg/repository/file_permission_filter_test.go`) cover every clause kind, multi-clause OR composition, single-clause wrapping, empty-clause dropping, and the no-op cases (nil filter / empty `Clauses`).
- Document the contract as `ARTIFACT-INV-LIST-FILES-PERMISSION-FILTER` in `AGENTS.md` so the post-filter pattern is not reintroduced and the generic-primitives boundary is preserved.

## Compatibility

- No proto / API changes. No migrations.
- Existing callers of `repository.ListFiles` and `PublicHandler.ListFiles` are unchanged.
- The new `PermissionFilter` field on `KnowledgeBaseFileListParams` defaults to `nil` (no-op).