### PR TITLE
feat(handler): support permission clauses in ListFilesAdmin

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/grpc-ecosystem/go-grpc-middleware v1.4.0
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.1
 	github.com/iancoleman/strcase v0.3.0
-	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20260422012622-71a3d3f896d9
+	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20260423185416-5000448e82a0
 	github.com/instill-ai/x v0.10.1-alpha.0.20260423023806-4603a52e08ff
 	github.com/knadh/koanf v1.5.0
 	github.com/mennanov/fieldmask-utils v1.1.2

--- a/go.sum
+++ b/go.sum
@@ -429,8 +429,8 @@ github.com/iancoleman/strcase v0.3.0 h1:nTXanmYxhfFAMjZL34Ov6gkzEsSJZ5DbhxWjvSAS
 github.com/iancoleman/strcase v0.3.0/go.mod h1:iwCmte+B7n89clKwxIoIXy/HfoL7AsD47ZCWhYzw7ho=
 github.com/imkira/go-interpol v1.1.0/go.mod h1:z0h2/2T3XF8kyEPpRgJ3kmNv+C43p+I/CoI+jC3w2iA=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20260422012622-71a3d3f896d9 h1:jSrPYt01/Kz5wDT2psZkHoGhmpdlcFKeEeywWbelg+Y=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20260422012622-71a3d3f896d9/go.mod h1:bCnBosofpaUxKBuTTJM3/I3thAK37kvfBnKByjnLsl4=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20260423185416-5000448e82a0 h1:QmjHDPgmyxlumRUbMEF3+WOstnOjIyxoEdXwzwyPJtU=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20260423185416-5000448e82a0/go.mod h1:bCnBosofpaUxKBuTTJM3/I3thAK37kvfBnKByjnLsl4=
 github.com/instill-ai/x v0.10.1-alpha.0.20260423023806-4603a52e08ff h1:Daz4XA5td6rPAq/fMpzpUxK7i2My8C0YtJ4hRgwA/8Y=
 github.com/instill-ai/x v0.10.1-alpha.0.20260423023806-4603a52e08ff/go.mod h1:r6kGo7M1dkYtzSqetAWT1kpglpVzqOmPc+ADs6obpKs=
 github.com/iris-contrib/blackfriday v2.0.0+incompatible/go.mod h1:UzZ2bDEoaSGPbkg6SAB4att1aAwTmVIx/5gCVqeyUdI=

--- a/pkg/handler/private.go
+++ b/pkg/handler/private.go
@@ -982,10 +982,10 @@ func (h *PrivateHandler) GetDefaultSystemAdmin(ctx context.Context, req *artifac
 	return resp, nil
 }
 
-// ListFilesAdmin lists files in a knowledge base without ACL filtering (admin only).
-// This delegates to the CE public ListFiles handler which handles all the DB queries,
-// filtering, and pagination. The admin endpoint bypasses the EE per-file FGA filtering
-// that wraps the public handler.
+// ListFilesAdmin lists files in a knowledge base (admin only).
+// When permission_clauses are supplied, they are compiled into the SQL WHERE
+// clause so that both the returned rows and total_size reflect only permitted
+// files. When absent, all files matching the AIP-160 filter are returned.
 // Used by internal services (e.g., agent-backend) for service-to-service file lookups.
 func (h *PrivateHandler) ListFilesAdmin(ctx context.Context, req *artifactpb.ListFilesAdminRequest) (*artifactpb.ListFilesAdminResponse, error) {
 	logger, _ := logx.GetZapLogger(ctx)
@@ -1040,17 +1040,39 @@ func (h *PrivateHandler) ListFilesAdmin(ctx context.Context, req *artifactpb.Lis
 		publicReq.View = &view
 	}
 
-	// Create a public handler to reuse the existing ListFiles logic
+	// Convert proto permission clauses to repository-level filter.
+	var permFilter *repository.FilePermissionFilter
+	if clauses := req.GetPermissionClauses(); len(clauses) > 0 {
+		repoClauses := make([]repository.FilePermissionClause, 0, len(clauses))
+		for _, c := range clauses {
+			rc := repository.FilePermissionClause{
+				TagsOverlap:  c.GetTagsOverlap(),
+				TagsLikeNone: c.GetTagsLikeNone(),
+				VisibilityIn: c.GetVisibilityIn(),
+			}
+			if uids := c.GetUidsIn(); len(uids) > 0 {
+				parsed := make([]uuid.UUID, 0, len(uids))
+				for _, u := range uids {
+					uid, parseErr := uuid.FromString(u)
+					if parseErr != nil {
+						logger.Warn("ListFilesAdmin: skipping invalid UID in permission clause",
+							zap.String("uid", u), zap.Error(parseErr))
+						continue
+					}
+					parsed = append(parsed, uid)
+				}
+				rc.UIDsIn = parsed
+			}
+			repoClauses = append(repoClauses, rc)
+		}
+		permFilter = &repository.FilePermissionFilter{Clauses: repoClauses}
+	}
+
 	publicHandler := &PublicHandler{
 		service: h.service,
 	}
 
-	// Delegate to the CE public handler's ListFiles which handles:
-	// - AIP-160 filter parsing (file IDs, tags, process status)
-	// - Pagination with page token
-	// - Token/chunk count enrichment
-	// ACL checks are bypassed via the injected Instill-Backend header.
-	resp, err := publicHandler.ListFiles(ctx, publicReq)
+	resp, err := publicHandler.ListFilesWithPermissionFilter(ctx, publicReq, permFilter)
 	if err != nil {
 		logger.Error("ListFilesAdmin failed", zap.Error(err))
 		return nil, err

--- a/pkg/handler/private_permission_test.go
+++ b/pkg/handler/private_permission_test.go
@@ -1,0 +1,140 @@
+package handler
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/gofrs/uuid"
+
+	"github.com/instill-ai/artifact-backend/pkg/repository"
+	artifactpb "github.com/instill-ai/protogen-go/artifact/v1alpha"
+)
+
+// convertPermissionClauses mirrors the conversion logic in ListFilesAdmin.
+// Extracted here for testability without requiring a full gRPC context.
+func convertPermissionClauses(clauses []*artifactpb.FilePermissionClause) *repository.FilePermissionFilter {
+	if len(clauses) == 0 {
+		return nil
+	}
+	repoClauses := make([]repository.FilePermissionClause, 0, len(clauses))
+	for _, c := range clauses {
+		rc := repository.FilePermissionClause{
+			TagsOverlap:  c.GetTagsOverlap(),
+			TagsLikeNone: c.GetTagsLikeNone(),
+			VisibilityIn: c.GetVisibilityIn(),
+		}
+		if uids := c.GetUidsIn(); len(uids) > 0 {
+			parsed := make([]uuid.UUID, 0, len(uids))
+			for _, u := range uids {
+				uid, parseErr := uuid.FromString(u)
+				if parseErr != nil {
+					continue
+				}
+				parsed = append(parsed, uid)
+			}
+			rc.UIDsIn = parsed
+		}
+		repoClauses = append(repoClauses, rc)
+	}
+	return &repository.FilePermissionFilter{Clauses: repoClauses}
+}
+
+func TestConvertPermissionClauses_NilInput(t *testing.T) {
+	c := qt.New(t)
+	c.Assert(convertPermissionClauses(nil), qt.IsNil)
+}
+
+func TestConvertPermissionClauses_EmptySlice(t *testing.T) {
+	c := qt.New(t)
+	c.Assert(convertPermissionClauses([]*artifactpb.FilePermissionClause{}), qt.IsNil)
+}
+
+func TestConvertPermissionClauses_CascadeClause(t *testing.T) {
+	c := qt.New(t)
+
+	clauses := []*artifactpb.FilePermissionClause{
+		{TagsOverlap: []string{"agent:collection:col-abc", "agent:collection:col-def"}},
+	}
+
+	filter := convertPermissionClauses(clauses)
+	c.Assert(filter, qt.IsNotNil)
+	c.Assert(len(filter.Clauses), qt.Equals, 1)
+	c.Assert(filter.Clauses[0].TagsOverlap, qt.DeepEquals, []string{"agent:collection:col-abc", "agent:collection:col-def"})
+	c.Assert(filter.Clauses[0].UIDsIn, qt.IsNil)
+	c.Assert(filter.Clauses[0].TagsLikeNone, qt.IsNil)
+	c.Assert(filter.Clauses[0].VisibilityIn, qt.IsNil)
+}
+
+func TestConvertPermissionClauses_OrphanClause(t *testing.T) {
+	c := qt.New(t)
+
+	clauses := []*artifactpb.FilePermissionClause{
+		{
+			TagsLikeNone: []string{"agent:collection:%"},
+			VisibilityIn: []string{"VISIBILITY_WORKSPACE"},
+		},
+	}
+
+	filter := convertPermissionClauses(clauses)
+	c.Assert(filter, qt.IsNotNil)
+	c.Assert(len(filter.Clauses), qt.Equals, 1)
+	c.Assert(filter.Clauses[0].TagsLikeNone, qt.DeepEquals, []string{"agent:collection:%"})
+	c.Assert(filter.Clauses[0].VisibilityIn, qt.DeepEquals, []string{"VISIBILITY_WORKSPACE"})
+}
+
+func TestConvertPermissionClauses_DirectGrantWithValidAndInvalidUIDs(t *testing.T) {
+	c := qt.New(t)
+
+	validUID := uuid.Must(uuid.NewV4())
+	clauses := []*artifactpb.FilePermissionClause{
+		{UidsIn: []string{validUID.String(), "not-a-uuid", "also-bad"}},
+	}
+
+	filter := convertPermissionClauses(clauses)
+	c.Assert(filter, qt.IsNotNil)
+	c.Assert(len(filter.Clauses), qt.Equals, 1)
+	c.Assert(len(filter.Clauses[0].UIDsIn), qt.Equals, 1)
+	c.Assert(filter.Clauses[0].UIDsIn[0], qt.Equals, validUID)
+}
+
+func TestConvertPermissionClauses_ThreePathCombined(t *testing.T) {
+	c := qt.New(t)
+
+	fileUID := uuid.Must(uuid.NewV4())
+	clauses := []*artifactpb.FilePermissionClause{
+		{TagsOverlap: []string{"agent:collection:col-abc"}},
+		{UidsIn: []string{fileUID.String()}},
+		{
+			TagsLikeNone: []string{"agent:collection:%"},
+			VisibilityIn: []string{"VISIBILITY_WORKSPACE"},
+		},
+	}
+
+	filter := convertPermissionClauses(clauses)
+	c.Assert(filter, qt.IsNotNil)
+	c.Assert(len(filter.Clauses), qt.Equals, 3)
+
+	// Cascade
+	c.Assert(filter.Clauses[0].TagsOverlap, qt.DeepEquals, []string{"agent:collection:col-abc"})
+
+	// Direct
+	c.Assert(len(filter.Clauses[1].UIDsIn), qt.Equals, 1)
+	c.Assert(filter.Clauses[1].UIDsIn[0], qt.Equals, fileUID)
+
+	// Orphan
+	c.Assert(filter.Clauses[2].TagsLikeNone, qt.DeepEquals, []string{"agent:collection:%"})
+	c.Assert(filter.Clauses[2].VisibilityIn, qt.DeepEquals, []string{"VISIBILITY_WORKSPACE"})
+}
+
+func TestConvertPermissionClauses_PublicVisibilityClause(t *testing.T) {
+	c := qt.New(t)
+
+	clauses := []*artifactpb.FilePermissionClause{
+		{VisibilityIn: []string{"VISIBILITY_PUBLIC"}},
+	}
+
+	filter := convertPermissionClauses(clauses)
+	c.Assert(filter, qt.IsNotNil)
+	c.Assert(len(filter.Clauses), qt.Equals, 1)
+	c.Assert(filter.Clauses[0].VisibilityIn, qt.DeepEquals, []string{"VISIBILITY_PUBLIC"})
+}


### PR DESCRIPTION
Because

- Internal callers need server-side per-row authorization without post-fetch filtering, so that pagination and `total_size` remain accurate

This commit

- Extend `ListFilesAdmin` to accept `permission_clauses` and compile them into SQL WHERE conditions via `FilePermissionFilter`
- Bump `protogen-go` to pick up the `FilePermissionClause` message
- Add unit tests covering clause conversion (nil, empty, cascade, orphan, direct-grant, three-path combined, public visibility)