### PR TITLE
fix(worker): eliminate reprocess-status flicker by persisting PROCESSING immediately

### DIFF
--- a/docs/invariants/README.md
+++ b/docs/invariants/README.md
@@ -11,6 +11,7 @@ On-demand reference for `ARTIFACT-INV-*` invariants. Read only the section relev
 | [`entity-aliases.md`](./entity-aliases.md) | `ARTIFACT-INV-ALIAS-BACKFILL` |
 | [`media-processing.md`](./media-processing.md) | `ARTIFACT-INV-MEDIA-DURATION-PROBE-FALLBACK`, `ARTIFACT-INV-VIDEO-REMUX-FAIL-FAST` |
 | [`storage-streaming.md`](./storage-streaming.md) | `ARTIFACT-INV-GCS-STREAM-RESUME`, `ARTIFACT-INV-MINIO-RANGE-OFFSET-ZERO`, `ARTIFACT-INV-MINIO-CLIENT-KEEPALIVE(TODO)` |
+| [`reprocess-status.md`](./reprocess-status.md) | `ARTIFACT-INV-reprocess-status-flicker-elimination` |
 
 ## Cross-cutting rules
 

--- a/docs/invariants/reprocess-status.md
+++ b/docs/invariants/reprocess-status.md
@@ -1,0 +1,24 @@
+# Reprocess status invariants
+
+## Reprocess-status flicker elimination (`ARTIFACT-INV-reprocess-status-flicker-elimination`)
+
+`file.process_status` is the single observable handle that downstream consumers (the console, downstream services that derive cell/preview status, anything paginating `ListFiles` with status filters) use to render whether a file is currently being processed. When `ProcessFileWorkflow` is restarted on a file whose persisted status is `FILE_PROCESS_STATUS_FAILED` or `FILE_PROCESS_STATUS_COMPLETED` — the auto-reprocess branch — the workflow MUST persist `FILE_PROCESS_STATUS_PROCESSING` to the database **before any stage-level activity runs**. Otherwise the gap between "the workflow has decided to reprocess" and "the next stage activity writes its own status" is an observable window where the UI re-reads the stale `FAILED` (or `COMPLETED`) row and surfaces a transient "Processing failed" badge / stale-completed thumbnail before the new pipeline lands.
+
+**Non-negotiable rules** (`pkg/worker/process_file_workflow.go`, `pkg/worker/status_activity.go`):
+
+1. **The auto-reprocess detection block persists immediately.** When the metadata-evaluation loop observes `startStatus ∈ {COMPLETED, FAILED}` and locally promotes it to `PROCESSING`, the workflow MUST execute `UpdateFileStatusActivity{Status: PROCESSING, Message: ""}` before returning to the loop or proceeding to Step 2. The local field assignment alone (`startStatus = PROCESSING`) is invisible to consumers — only the activity write is.
+2. **The persistence is fire-and-forget on failure.** The workflow MUST log a `Warn` and continue if the persistence call errors. A missed write degrades gracefully back to the pre-fix flicker (Step 2a's later persistence still fires); blocking the reprocess on this write would replace a UX flicker with an outage.
+3. **Step 2a's `UpdateFileStatusActivity(PROCESSING)` stays.** The new persistence is additive: Step 2a's per-file write at the start of full-processing remains, both because it covers the originally-`NOTSTARTED` / `PROCESSING` cases (which never enter the auto-reprocess detection block) and because it is the structural marker that "Step 2 is starting." Removing it would re-introduce the flicker for non-auto-reprocess paths.
+4. **Activity ordering is enforced by test, not by comment.** The deterministic Temporal `WorkflowEnvironment` test `TestProcessFileWorkflow_AutoReprocessFromFailed_PersistsProcessingBeforeAnyOtherActivity` counts `UpdateFileStatusActivity` calls before the first `DeleteOldConvertedFilesActivity` (the first stage activity in Step 2b). Pre-fix the count is 1 (Step 2a); post-fix the count is 2 (auto-reprocess persistence + Step 2a). The test asserts `>= 2` and freezes the contract — removing the new persistence drops the count back to 1 and turns the test red.
+
+**Why this fix is elegant, robust, and future-proof:**
+
+- **Elegant** — single insertion point inside the existing auto-reprocess detection block. No new activities, no new RPC, no new state machine. Reuses the activity that every other status transition in this file already calls.
+- **Robust** — handles all auto-reprocess paths uniformly because the detection block is the single gate (`startStatus ∈ {COMPLETED, FAILED}`). The fire-and-forget envelope means a transient DB error degrades to the pre-fix flicker rather than to a stuck file.
+- **Future-proof** — every future starting status that enters the auto-reprocess branch (e.g. a hypothetical `PARTIAL_FAILURE` added to `FileProcessStatus`) inherits the persistence behaviour for free; the rule is "if the local mutation runs, the activity runs."
+
+**Regression case:** auto-reprocess of an image cell whose initial run had failed produced a transient "Processing failed" badge in the cell card before the regenerated image rendered. Pre-fix: the workflow's metadata loop ran `GetFileStatus` → `GetFileMetadata` → set `startStatus = PROCESSING` (locally only) → exited the loop → entered Step 2 → Step 2a's `UpdateFileStatusActivity(PROCESSING)` was the first DB write of `PROCESSING`. The console's polling read of `file.process_status` between the metadata loop ending and Step 2a starting saw `FAILED`, rendered the "Processing failed" cell, and only later (after Step 2a's write reached the DB) re-rendered with the regenerated image.
+
+**Tests pinning this invariant:**
+
+- `pkg/worker/process_file_workflow_test.go::TestProcessFileWorkflow_AutoReprocessFromFailed_PersistsProcessingBeforeAnyOtherActivity` — Temporal `testsuite.WorkflowEnvironment` + `OnActivity` recorder. Mocks a file with `ProcessStatus = FILE_PROCESS_STATUS_FAILED`; asserts `>= 2` `UpdateFileStatusActivity` calls before the first `DeleteOldConvertedFilesActivity`, and that every status persisted in that window is `PROCESSING`.

--- a/pkg/worker/process_file_workflow.go
+++ b/pkg/worker/process_file_workflow.go
@@ -360,6 +360,29 @@ func (w *Worker) ProcessFileWorkflow(ctx workflow.Context, param ProcessFileWork
 				"fileUID", fileUID.String(),
 				"previousStatus", startStatus.String())
 			startStatus = artifactpb.FileProcessStatus_FILE_PROCESS_STATUS_PROCESSING
+
+			// Persist PROCESSING immediately so callers that derive UI state
+			// from file.process_status (e.g. cell-status derivation in
+			// downstream consumers) never observe a stale FAILED/COMPLETED
+			// row while the auto-reprocess is in flight. Without this, the
+			// DB stays on the previous status until the first stage-level
+			// activity runs and writes its own status update — that gap is
+			// observed in the UI as a transient "Processing failed" /
+			// stale-COMPLETED flicker before the new pipeline lands.
+			//
+			// The activity is fire-and-forget on failure: a missed status
+			// write degrades gracefully back to the pre-fix flicker rather
+			// than blocking the reprocess. See
+			// ARTIFACT-INV-reprocess-status-flicker-elimination in
+			// docs/invariants/reprocess-status.md.
+			if err := workflow.ExecuteActivity(ctx, w.UpdateFileStatusActivity, &UpdateFileStatusActivityParam{
+				FileUID: fileUID,
+				Status:  artifactpb.FileProcessStatus_FILE_PROCESS_STATUS_PROCESSING,
+				Message: "",
+			}).Get(ctx, nil); err != nil {
+				logger.Warn("Failed to persist PROCESSING status on auto-reprocess",
+					"fileUID", fileUID.String(), "error", err)
+			}
 		}
 
 		bucket := object.BucketFromDestination(metadata.File.StoragePath)

--- a/pkg/worker/process_file_workflow_test.go
+++ b/pkg/worker/process_file_workflow_test.go
@@ -1,11 +1,14 @@
 package worker
 
 import (
+	"context"
 	"fmt"
+	"sync"
 	"testing"
 
 	"github.com/gofrs/uuid"
 	"github.com/gojuno/minimock/v3"
+	tmock "github.com/stretchr/testify/mock"
 	"go.temporal.io/sdk/testsuite"
 	"go.uber.org/zap"
 
@@ -13,6 +16,8 @@ import (
 
 	"github.com/instill-ai/artifact-backend/pkg/repository"
 	"github.com/instill-ai/artifact-backend/pkg/worker/mock"
+
+	artifactpb "github.com/instill-ai/protogen-go/artifact/v1alpha"
 )
 
 func TestProcessFileWorkflowParam_Validation(t *testing.T) {
@@ -333,5 +338,146 @@ func TestProcessFileWorkflow_GetFileMetadataSuccess(t *testing.T) {
 		// Expected - workflow fails at processing stages due to missing mocks
 		// As long as it's not an ActivityNotRegisteredError, the test validates what we need
 		c.Logf("Workflow failed as expected at processing stages: %v", err)
+	}
+}
+
+// TestProcessFileWorkflow_AutoReprocessFromFailed_PersistsProcessingBeforeAnyOtherActivity
+// pins ARTIFACT-INV-reprocess-status-flicker-elimination
+// (docs/invariants/reprocess-status.md).
+//
+// When ProcessFileWorkflow is restarted on a file whose
+// process_status is FAILED (or COMPLETED), the workflow MUST persist
+// FILE_PROCESS_STATUS_PROCESSING to the database BEFORE any
+// stage-level activity runs. Otherwise downstream consumers that
+// derive UI state from file.process_status read the stale FAILED row
+// during the gap and surface a transient "Processing failed" flicker
+// before the new pipeline writes the next status.
+//
+// The deterministic Temporal testsuite is the canonical executable
+// contract for this class of bug — k6 polling cannot observe the
+// sub-second window reliably; the workflow-environment harness can.
+func TestProcessFileWorkflow_AutoReprocessFromFailed_PersistsProcessingBeforeAnyOtherActivity(t *testing.T) {
+	c := qt.New(t)
+	mc := minimock.NewController(c)
+
+	mockRepository := mock.NewRepositoryMock(mc)
+	mockAIClient := mock.NewClientMock(mc)
+
+	fileUID := uuid.Must(uuid.NewV4())
+	kbUID := uuid.Must(uuid.NewV4())
+
+	// File starts in FAILED — the auto-reprocess branch this invariant
+	// guards is entered when startStatus is FAILED or COMPLETED.
+	mockRepository.GetFilesByFileUIDsMock.Return([]repository.FileModel{
+		{
+			UID:           fileUID,
+			ProcessStatus: artifactpb.FileProcessStatus_FILE_PROCESS_STATUS_FAILED.String(),
+			DisplayName:   "anchor.png",
+			FileType:      "TYPE_PDF",
+			StoragePath:   "test/anchor.png",
+		},
+	}, nil)
+	mockRepository.GetKnowledgeBaseByUIDWithConfigMock.Return(&repository.KnowledgeBaseWithConfig{
+		KnowledgeBaseModel: repository.KnowledgeBaseModel{UID: kbUID},
+	}, nil)
+	mockRepository.GetKnowledgeBaseByUIDMock.Return(&repository.KnowledgeBaseModel{
+		UID:     kbUID,
+		Staging: false,
+	}, nil)
+	mockRepository.GetDualProcessingTargetMock.Return(nil, nil)
+
+	testSuite := &testsuite.WorkflowTestSuite{}
+	env := testSuite.NewTestWorkflowEnvironment()
+
+	w := &Worker{
+		repository: mockRepository,
+		aiClient:   mockAIClient,
+		log:        zap.NewNop(),
+	}
+
+	// Activity-call recorder. We capture every UpdateFileStatusActivity
+	// invocation in order, plus the first stage activity
+	// (DeleteOldConvertedFilesActivity is the next activity the
+	// workflow runs after the auto-reprocess branch enters PROCESSING),
+	// so we can prove ordering.
+	var (
+		mu               sync.Mutex
+		callOrder        []string
+		statusCallParams []artifactpb.FileProcessStatus
+	)
+
+	env.OnActivity(w.UpdateFileStatusActivity, tmock.Anything, tmock.Anything).Return(
+		func(_ context.Context, p *UpdateFileStatusActivityParam) error {
+			mu.Lock()
+			defer mu.Unlock()
+			callOrder = append(callOrder, "UpdateFileStatus")
+			statusCallParams = append(statusCallParams, p.Status)
+			return nil
+		},
+	)
+	env.OnActivity(w.DeleteOldConvertedFilesActivity, tmock.Anything, tmock.Anything).Return(
+		func(_ context.Context, _ *DeleteOldConvertedFilesActivityParam) error {
+			mu.Lock()
+			defer mu.Unlock()
+			callOrder = append(callOrder, "DeleteOldConvertedFiles")
+			return nil
+		},
+	)
+
+	env.RegisterActivity(w.GetFileMetadataActivity)
+	env.RegisterActivity(w.GetFileStatusActivity)
+	env.RegisterWorkflow(w.ProcessFileWorkflow)
+
+	param := ProcessFileWorkflowParam{
+		FileUIDs: []uuid.UUID{fileUID},
+		KBUID:    kbUID,
+	}
+
+	env.ExecuteWorkflow(w.ProcessFileWorkflow, param)
+
+	c.Assert(env.IsWorkflowCompleted(), qt.IsTrue)
+
+	// Look at the activity-call order up to the first
+	// DeleteOldConvertedFiles call — that's the boundary between the
+	// metadata-evaluation phase (where the auto-reprocess persistence
+	// MUST land) and the stage-activity phase (which would let the UI
+	// observe the stale FAILED row if persistence is delayed past it).
+	mu.Lock()
+	defer mu.Unlock()
+
+	c.Assert(len(callOrder) > 0, qt.IsTrue,
+		qt.Commentf("expected at least one activity call; got none"))
+
+	// Find the boundary: index of the first non-UpdateFileStatus
+	// activity. Everything before it MUST be UpdateFileStatus. The
+	// pre-fix workflow runs one UpdateFileStatus(PROCESSING) before
+	// the first stage activity (Step 2a, "Update all files status to
+	// PROCESSING"); the post-fix workflow runs two — the new
+	// auto-reprocess persistence + Step 2a — and both MUST land before
+	// the first stage activity. Asserting >= 2 freezes the contract:
+	// removing the auto-reprocess persistence (regression) drops the
+	// count to 1 and turns this test red.
+	statusCountBeforeStage := 0
+	for _, call := range callOrder {
+		if call == "UpdateFileStatus" {
+			statusCountBeforeStage++
+			continue
+		}
+		break
+	}
+	c.Assert(statusCountBeforeStage >= 2, qt.IsTrue,
+		qt.Commentf("auto-reprocess from FAILED must persist PROCESSING immediately + at the start of full processing — expected >= 2 UpdateFileStatus calls before the first stage activity, got %d. Full order: %v",
+			statusCountBeforeStage, callOrder))
+
+	// All persisted statuses observed before the first stage activity
+	// MUST be PROCESSING. A persisted FAILED or COMPLETED in this
+	// window would mean the workflow regressed to writing a wrong
+	// status (e.g. the handleFileError branch ran early) and would
+	// itself produce a flicker.
+	for i := 0; i < statusCountBeforeStage; i++ {
+		c.Assert(statusCallParams[i], qt.Equals,
+			artifactpb.FileProcessStatus_FILE_PROCESS_STATUS_PROCESSING,
+			qt.Commentf("UpdateFileStatus call #%d before first stage activity persisted %v, expected PROCESSING. Full statuses: %v",
+				i, statusCallParams[i], statusCallParams))
 	}
 }


### PR DESCRIPTION
**Because**

- When `ProcessFileWorkflow` auto-reprocesses a FAILED or COMPLETED file, the local `startStatus` promotion to PROCESSING was invisible to DB consumers until Step 2a's `UpdateFileStatusActivity` ran — leaving a window where the UI read the stale FAILED row and surfaced a transient "Processing failed" badge before the regenerated result appeared.

**This commit**

- Persists `FILE_PROCESS_STATUS_PROCESSING` via `UpdateFileStatusActivity` immediately inside the auto-reprocess detection block, before any stage-level activity runs. The write is fire-and-forget: failure degrades to the pre-fix flicker rather than blocking the pipeline.
- Adds `ARTIFACT-INV-reprocess-status-flicker-elimination` invariant doc and a deterministic Temporal testsuite test that asserts >= 2 `UpdateFileStatus(PROCESSING)` calls before the first stage activity.


Made with [Cursor](https://cursor.com)