### PR TITLE
fix(chunk): add trusted-backend bypass for ListChunks ACL

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/grpc-ecosystem/go-grpc-middleware v1.4.0
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.1
 	github.com/iancoleman/strcase v0.3.0
-	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20260423185416-5000448e82a0
+	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20260429232800-7b4efe2cd9e9
 	github.com/instill-ai/x v0.10.1-alpha.0.20260423023806-4603a52e08ff
 	github.com/knadh/koanf v1.5.0
 	github.com/mennanov/fieldmask-utils v1.1.2

--- a/go.sum
+++ b/go.sum
@@ -429,8 +429,8 @@ github.com/iancoleman/strcase v0.3.0 h1:nTXanmYxhfFAMjZL34Ov6gkzEsSJZ5DbhxWjvSAS
 github.com/iancoleman/strcase v0.3.0/go.mod h1:iwCmte+B7n89clKwxIoIXy/HfoL7AsD47ZCWhYzw7ho=
 github.com/imkira/go-interpol v1.1.0/go.mod h1:z0h2/2T3XF8kyEPpRgJ3kmNv+C43p+I/CoI+jC3w2iA=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20260423185416-5000448e82a0 h1:QmjHDPgmyxlumRUbMEF3+WOstnOjIyxoEdXwzwyPJtU=
-github.com/instill-ai/protogen-go v0.3.3-alpha.0.20260423185416-5000448e82a0/go.mod h1:bCnBosofpaUxKBuTTJM3/I3thAK37kvfBnKByjnLsl4=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20260429232800-7b4efe2cd9e9 h1:HtM0U3FchreDXc0A2j0LS3cIleYZKFTlyeG3yGXo+gc=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20260429232800-7b4efe2cd9e9/go.mod h1:bCnBosofpaUxKBuTTJM3/I3thAK37kvfBnKByjnLsl4=
 github.com/instill-ai/x v0.10.1-alpha.0.20260423023806-4603a52e08ff h1:Daz4XA5td6rPAq/fMpzpUxK7i2My8C0YtJ4hRgwA/8Y=
 github.com/instill-ai/x v0.10.1-alpha.0.20260423023806-4603a52e08ff/go.mod h1:r6kGo7M1dkYtzSqetAWT1kpglpVzqOmPc+ADs6obpKs=
 github.com/iris-contrib/blackfriday v2.0.0+incompatible/go.mod h1:UzZ2bDEoaSGPbkg6SAB4att1aAwTmVIx/5gCVqeyUdI=

--- a/pkg/handler/chunk.go
+++ b/pkg/handler/chunk.go
@@ -278,29 +278,38 @@ func (ph *PublicHandler) ListChunks(ctx context.Context, req *artifactpb.ListChu
 	fileUID := uuid.UUID(kbf.UID)
 	_ = namespaceID // namespaceID can be used for validation if needed
 
-	// ACL - check user's permission to read any of the knowledge bases associated with this file
-	kbUIDs, err := ph.service.Repository().GetKnowledgeBaseUIDsForFile(ctx, kbf.UID)
-	if err != nil {
-		logger.Error("failed to get KB associations for file", zap.Error(err))
-		return nil, fmt.Errorf("getting file KB associations: %w", err)
-	}
-	if len(kbUIDs) == 0 {
-		return nil, fmt.Errorf("%w: file not associated with any knowledge base", errorsx.ErrNotFound)
-	}
-	granted := false
-	for _, kbUID := range kbUIDs {
-		hasPermission, err := ph.service.ACLClient().CheckPermission(ctx, "knowledgebase", kbUID, "reader")
+	// ACL - check user's permission to read any of the knowledge bases
+	// associated with this file.
+	//
+	// Trusted backend-to-backend calls that have already performed
+	// file-level authorization bypass this KB-level check. Re-checking
+	// KB membership here would reject callers the upstream layer has
+	// already validated. This mirrors the trusted-backend bypass on
+	// `SimilarityChunksSearch` lower in this file.
+	if !service.IsTrustedBackendRequest(ctx) {
+		kbUIDs, err := ph.service.Repository().GetKnowledgeBaseUIDsForFile(ctx, kbf.UID)
 		if err != nil {
-			logger.Warn("failed to check permission for KB", zap.Error(err), zap.String("kbUID", kbUID.String()))
-			continue
+			logger.Error("failed to get KB associations for file", zap.Error(err))
+			return nil, fmt.Errorf("getting file KB associations: %w", err)
 		}
-		if hasPermission {
-			granted = true
-			break
+		if len(kbUIDs) == 0 {
+			return nil, fmt.Errorf("%w: file not associated with any knowledge base", errorsx.ErrNotFound)
 		}
-	}
-	if !granted {
-		return nil, fmt.Errorf("%w: no permission over knowledge base", errorsx.ErrUnauthorized)
+		granted := false
+		for _, kbUID := range kbUIDs {
+			hasPermission, err := ph.service.ACLClient().CheckPermission(ctx, "knowledgebase", kbUID, "reader")
+			if err != nil {
+				logger.Warn("failed to check permission for KB", zap.Error(err), zap.String("kbUID", kbUID.String()))
+				continue
+			}
+			if hasPermission {
+				granted = true
+				break
+			}
+		}
+		if !granted {
+			return nil, fmt.Errorf("%w: no permission over knowledge base", errorsx.ErrUnauthorized)
+		}
 	}
 	// Get ALL text chunks for this file (content + summary + augmented)
 	// Note: A file can have multiple converted_files (e.g., content converted_file + summary converted_file)


### PR DESCRIPTION
## Summary

- Wrap the KB-level ACL check in `ListChunks` with `IsTrustedBackendRequest`, mirroring the existing bypass on `SimilarityChunksSearch`
- Trusted backend-to-backend calls that have already performed file-level authorization no longer get rejected by the KB membership check
- Bump `protogen-go` dependency to latest

## Because

- Share-link visitors and cross-workspace users whose file access was already validated by the upstream layer were hitting `NOT_FOUND` on `ListChunks` because the CE KB-level ACL re-check failed for callers without direct KB reader permission

## Test plan

- [x] `IsTrustedBackendRequest` has existing unit tests in `utils_test.go` (header present → trusted, absent → not trusted)
- [x] Same guard pattern already runs in production on `SimilarityChunksSearch`