### PR TITLE
feat(handler): populate File.ParentProject from DB column in API responses

### DIFF
--- a/pkg/handler/converter.go
+++ b/pkg/handler/converter.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/instill-ai/artifact-backend/pkg/repository"
 	"github.com/instill-ai/artifact-backend/pkg/resource"
+	"github.com/instill-ai/artifact-backend/pkg/types"
 
 	artifactpb "github.com/instill-ai/protogen-go/artifact/v1alpha"
 	mgmtpb "github.com/instill-ai/protogen-go/mgmt/v1beta"
@@ -135,6 +136,19 @@ func creatorResourceName(user *mgmtpb.User) string {
 	return ""
 }
 
+// ptrStringFromUUIDPointer converts a `*uuid.UUID` column value (e.g.
+// `FileModel.ParentProjectUID`) into the `*string` form expected by the
+// oneof-wrapped proto field `File.ParentProject`. Returns nil when the
+// column is NULL so the field stays unset in the wire response (and
+// JSON-marshals to an absent key thanks to `proto3,oneof,omitempty`).
+func ptrStringFromUUIDPointer(u *types.ProjectUIDType) *string {
+	if u == nil {
+		return nil
+	}
+	s := u.String()
+	return &s
+}
+
 // convertKBFileToPB converts database FileModel to protobuf File.
 // The `name` field is computed dynamically following other backends' patterns.
 // The objectID parameter is the hash-based object ID (e.g., "obj-abc123") for AIP-122 compliant resource references.
@@ -172,6 +186,7 @@ func convertKBFileToPB(kbf *repository.FileModel, ns *resource.Namespace, kb *re
 		ProcessStatus:      convertFileProcessStatus(kbf.ProcessStatus),
 		Aliases:            kbf.Aliases,
 		Visibility:         convertFileVisibility(kbf.Visibility),
+		ParentProject:      ptrStringFromUUIDPointer(kbf.ParentProjectUID),
 	}
 
 	// Handle optional fields

--- a/pkg/handler/file.go
+++ b/pkg/handler/file.go
@@ -702,6 +702,13 @@ func (ph *PublicHandler) CreateFile(ctx context.Context, req *artifactpb.CreateF
 			Collections:        extractCollectionIDs(res.Tags),
 			ContentSha256:      res.ContentSHA256,
 			Visibility:         convertFileVisibility(res.Visibility),
+			// ParentProject may still be nil here when the column is
+			// populated by an EE follow-up write (e.g.
+			// artifact-backend-ee's `SetParentProjectUID`) after the CE
+			// INSERT returns. A subsequent GetFile picks up the value;
+			// the CreateFile response surfaces it whenever the column is
+			// already set by the time CE finishes inserting.
+			ParentProject: ptrStringFromUUIDPointer(res.ParentProjectUID),
 		},
 	}, nil
 }
@@ -1071,6 +1078,7 @@ func (ph *PublicHandler) ListFilesWithPermissionFilter(ctx context.Context, req 
 			IsTextBased:        kbFile.IsTextBased,
 			ContentSha256:      kbFile.ContentSHA256,
 			Visibility:         convertFileVisibility(kbFile.Visibility),
+			ParentProject:      ptrStringFromUUIDPointer(kbFile.ParentProjectUID),
 		}
 
 		// Include status message (error or success message)
@@ -2312,80 +2320,80 @@ func (ph *PublicHandler) UpdateFile(ctx context.Context, req *artifactpb.UpdateF
 						}
 					}
 				}
-		case "content":
-			patchContent := strings.TrimSpace(req.GetFile().GetContent())
-			patchPath := fmt.Sprintf("kb-%s/file-%s/%s/patch.md", kbUIDs[0].String(), kbFile.UID.String(), object.ConvertedFileDir)
-			bucket := config.Config.Minio.BucketName
-			storage := ph.service.Repository().GetMinIOStorage()
+			case "content":
+				patchContent := strings.TrimSpace(req.GetFile().GetContent())
+				patchPath := fmt.Sprintf("kb-%s/file-%s/%s/patch.md", kbUIDs[0].String(), kbFile.UID.String(), object.ConvertedFileDir)
+				bucket := config.Config.Minio.BucketName
+				storage := ph.service.Repository().GetMinIOStorage()
 
-			if patchContent != "" {
-				requesterUserID := "unknown"
-				if md, ok := metadata.FromIncomingContext(ctx); ok {
-					if vals := md.Get("instill-requester-user-id"); len(vals) > 0 {
-						requesterUserID = vals[0]
+				if patchContent != "" {
+					requesterUserID := "unknown"
+					if md, ok := metadata.FromIncomingContext(ctx); ok {
+						if vals := md.Get("instill-requester-user-id"); len(vals) > 0 {
+							requesterUserID = vals[0]
+						}
 					}
-				}
 
-				var existing string
-				if existingBytes, err := storage.GetFile(ctx, bucket, patchPath); err == nil {
-					existing = string(existingBytes)
-				}
+					var existing string
+					if existingBytes, err := storage.GetFile(ctx, bucket, patchPath); err == nil {
+						existing = string(existingBytes)
+					}
 
-				newEntry := fmt.Sprintf("---\n[%s] by %s\n%s\n", time.Now().UTC().Format(time.RFC3339), requesterUserID, patchContent)
-				combined := existing + newEntry
+					newEntry := fmt.Sprintf("---\n[%s] by %s\n%s\n", time.Now().UTC().Format(time.RFC3339), requesterUserID, patchContent)
+					combined := existing + newEntry
 
-				b64 := base64.StdEncoding.EncodeToString([]byte(combined))
-				if err := storage.UploadBase64File(ctx, bucket, patchPath, b64, "text/markdown"); err != nil {
-					return nil, errorsx.AddMessage(
-						fmt.Errorf("writing patch.md: %w", err),
-						"Failed to store patch content.",
-					)
+					b64 := base64.StdEncoding.EncodeToString([]byte(combined))
+					if err := storage.UploadBase64File(ctx, bucket, patchPath, b64, "text/markdown"); err != nil {
+						return nil, errorsx.AddMessage(
+							fmt.Errorf("writing patch.md: %w", err),
+							"Failed to store patch content.",
+						)
+					}
+					// Set patch flag in ExternalMetadata
+					em := kbFile.ExternalMetadataUnmarshal
+					if em == nil {
+						em = &structpb.Struct{Fields: map[string]*structpb.Value{}}
+					}
+					if em.Fields == nil {
+						em.Fields = map[string]*structpb.Value{}
+					}
+					em.Fields["x-instill-patch"] = structpb.NewStringValue("true")
+					emJSON, err := protojson.Marshal(em)
+					if err != nil {
+						return nil, errorsx.AddMessage(
+							fmt.Errorf("serializing external metadata: %w", err),
+							"Failed to process patch metadata.",
+						)
+					}
+					updates[repository.FileColumn.ExternalMetadata] = string(emJSON)
+					logger.Info("Appended to patch.md and set ExternalMetadata flag",
+						zap.String("fileUID", kbFile.UID.String()),
+						zap.String("patchPath", patchPath))
+				} else {
+					// Clear: delete patch.md and remove patch flag
+					_ = storage.DeleteFile(ctx, bucket, patchPath)
+					em := kbFile.ExternalMetadataUnmarshal
+					if em != nil && em.Fields != nil {
+						delete(em.Fields, "x-instill-patch")
+					}
+					if em == nil {
+						em = &structpb.Struct{Fields: map[string]*structpb.Value{}}
+					}
+					emJSON, err := protojson.Marshal(em)
+					if err != nil {
+						return nil, errorsx.AddMessage(
+							fmt.Errorf("serializing external metadata: %w", err),
+							"Failed to process patch metadata.",
+						)
+					}
+					updates[repository.FileColumn.ExternalMetadata] = string(emJSON)
+					logger.Info("Cleared patch.md and removed patch ExternalMetadata flag",
+						zap.String("fileUID", kbFile.UID.String()))
 				}
-				// Set patch flag in ExternalMetadata
-				em := kbFile.ExternalMetadataUnmarshal
-				if em == nil {
-					em = &structpb.Struct{Fields: map[string]*structpb.Value{}}
-				}
-				if em.Fields == nil {
-					em.Fields = map[string]*structpb.Value{}
-				}
-				em.Fields["x-instill-patch"] = structpb.NewStringValue("true")
-				emJSON, err := protojson.Marshal(em)
-				if err != nil {
-					return nil, errorsx.AddMessage(
-						fmt.Errorf("serializing external metadata: %w", err),
-						"Failed to process patch metadata.",
-					)
-				}
-				updates[repository.FileColumn.ExternalMetadata] = string(emJSON)
-				logger.Info("Appended to patch.md and set ExternalMetadata flag",
-					zap.String("fileUID", kbFile.UID.String()),
-					zap.String("patchPath", patchPath))
-			} else {
-				// Clear: delete patch.md and remove patch flag
-				_ = storage.DeleteFile(ctx, bucket, patchPath)
-				em := kbFile.ExternalMetadataUnmarshal
-				if em != nil && em.Fields != nil {
-					delete(em.Fields, "x-instill-patch")
-				}
-				if em == nil {
-					em = &structpb.Struct{Fields: map[string]*structpb.Value{}}
-				}
-				emJSON, err := protojson.Marshal(em)
-				if err != nil {
-					return nil, errorsx.AddMessage(
-						fmt.Errorf("serializing external metadata: %w", err),
-						"Failed to process patch metadata.",
-					)
-				}
-				updates[repository.FileColumn.ExternalMetadata] = string(emJSON)
-				logger.Info("Cleared patch.md and removed patch ExternalMetadata flag",
-					zap.String("fileUID", kbFile.UID.String()))
-			}
-		case "external_metadata":
-			// Update external metadata
-			updates[repository.FileColumn.ExternalMetadata] = req.File.ExternalMetadata
-		case "tags":
+			case "external_metadata":
+				// Update external metadata
+				updates[repository.FileColumn.ExternalMetadata] = req.File.ExternalMetadata
+			case "tags":
 				// Validate user-provided tags don't use reserved prefixes
 				if err := validateUserTags(req.File.Tags); err != nil {
 					return nil, err

--- a/pkg/handler/private.go
+++ b/pkg/handler/private.go
@@ -700,6 +700,7 @@ func (h *PrivateHandler) ReprocessFileAdmin(ctx context.Context, req *artifactpb
 		Size:          updatedFile.Size,
 		ContentSha256: updatedFile.ContentSHA256,
 		Visibility:    convertFileVisibility(updatedFile.Visibility),
+		ParentProject: ptrStringFromUUIDPointer(updatedFile.ParentProjectUID),
 	}
 	if updatedFile.CreateTime != nil {
 		pbFile.CreateTime = timestamppb.New(*updatedFile.CreateTime)

--- a/pkg/repository/create_file_admin_test.go
+++ b/pkg/repository/create_file_admin_test.go
@@ -50,7 +50,8 @@ func setupTestDB(t *testing.T) *gorm.DB {
 			usage_metadata TEXT,
 			content_sha256 TEXT,
 			is_text_based BOOLEAN DEFAULT FALSE,
-			visibility TEXT NOT NULL DEFAULT 'VISIBILITY_WORKSPACE'
+			visibility TEXT NOT NULL DEFAULT 'VISIBILITY_WORKSPACE',
+			parent_project_uid TEXT
 		)`,
 		`CREATE TABLE file_knowledge_base (
 			file_uid TEXT NOT NULL,

--- a/pkg/repository/file.go
+++ b/pkg/repository/file.go
@@ -209,6 +209,20 @@ type FileModel struct {
 	// "VISIBILITY_WORKSPACE", "VISIBILITY_LINK_SHARED"). Defaults to
 	// VISIBILITY_WORKSPACE so org members can access the file.
 	Visibility string `gorm:"column:visibility;not null;default:VISIBILITY_WORKSPACE" json:"visibility"`
+	// ParentProjectUID is the file's folder (project) home, the single
+	// permission parent under the Folder–File Permission Model. NULL means
+	// "no folder assigned yet" — every live file should have a non-NULL
+	// value once the EE backfill (agent-backend-ee convert000132) has run.
+	//
+	// Edition-boundary note: the underlying column DDL is shipped by the
+	// EE migration `000071_add_parent_project_uid_to_file` in
+	// artifact-backend-ee. CE only declares the GORM field so the read
+	// path can populate the corresponding proto field
+	// (`File.ParentProject`). CE never writes the column today; the write
+	// happens through artifact-backend-ee's `EEFileRepository.SetParentProjectUID`.
+	// When the column moves into CE ownership (planned follow-up), this
+	// note can be removed.
+	ParentProjectUID *types.ProjectUIDType `gorm:"column:parent_project_uid;type:uuid" json:"parent_project_uid,omitempty"`
 }
 
 // TableName overrides the default table name for GORM

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -102,6 +102,12 @@ type (
 	CollectionUIDType = uuid.UUID
 	// FileUIDType is the File unique identifier
 	FileUIDType = uuid.UUID
+	// ProjectUIDType is the Project (folder) unique identifier. A file
+	// optionally references its parent project via
+	// `FileModel.ParentProjectUID`; the column itself is added by an EE
+	// migration today (artifact-backend-ee 000071_add_parent_project_uid_to_file),
+	// see the FileModel comment for the edition-boundary note.
+	ProjectUIDType = uuid.UUID
 	// ChunkUIDType is the Text chunk unique identifier
 	ChunkUIDType = uuid.UUID
 	// ConvertedFileUIDType is the Converted file unique identifier


### PR DESCRIPTION
## Because

- The `parent_project_uid` column has shipped on the `file` table since
  artifact-backend-ee migration `000071` (Phase 4 #189), and EE
  `EEFileRepository.SetParentProjectUID` populates it at file
  creation. **The CE read path was never wired up**: every File-proto
  construction in `pkg/handler/{file,converter,private}.go` omitted the
  `ParentProject` field, so the column round-tripped through the DB
  without ever surfacing on the wire — `parentProject` is absent from
  `GetFile` / `ListFiles` / `ListFilesAdmin` JSON responses today,
  despite the column being non-NULL.
- This blocks agent-backend-ee's R1 **Folder–File Permission Model**.
  The in-process permission filter
  (`agent-backend-ee/pkg/service/file_permission_filter.go`) reads
  `file.GetParentProject()` to evaluate the folder cascade per request.
  With the proto field empty, the in-process path is silently broken.
  Production happens to work because the active codepath today is
  `BuildPermissionClauses` → SQL push-down via `ParentProjectUidIn`
  against the DB column directly (which is correctly populated).
- Surfaced by a k6 integration test
  (`agent-backend-ee/integration-test/standalone-cascade-files.js`
  INV-1 assertion) failing on a stack where the DB column was verified
  populated via `commander db artifact --query ...`.

## This commit

### Repository layer
- Declare `FileModel.ParentProjectUID *types.ProjectUIDType` so GORM
  reads the existing column. The column DDL is still owned by the EE
  migration today (the field comment carries the edition-boundary
  note) — moving the migration into CE is a planned follow-up that
  makes CE schema-self-sufficient.
- Add `types.ProjectUIDType = uuid.UUID` to match the existing
  `FileUIDType` / `CollectionUIDType` aliases.

### Handler layer
- New helper `ptrStringFromUUIDPointer(u *uuid.UUID) *string` in
  `converter.go`. Bridges the nullable `*uuid.UUID` column to the
  oneof-wrapped proto field `File.ParentProject` (`*string`,
  `proto3,oneof,omitempty`); returns nil for NULL columns so the JSON
  response omits the key entirely (matching pre-PR shape for
  unmigrated files).
- Populate `ParentProject` in the four `&artifactpb.File{...}`
  construction sites:
  - `convertKBFileToPB` (shared `GetFile` / cascade path)
  - `CreateFile` response in `file.go:679`
  - `ListFiles` row in `file.go:1046`
  - `ReprocessFileAdmin` response in `private.go:694`
  No site refactoring beyond adding the one field. Behavioural
  contract unchanged for every other field.

### Tests
- Extend the CE in-memory sqlite test schema in
  `create_file_admin_test.go` with the `parent_project_uid` column so
  the now-declared GORM field round-trips cleanly through `INSERT`.
  Production tests unaffected because Postgres already has the column
  via the EE migration.

## Edition-boundary note

This PR adds the **CE read side** of the column, not its schema. The
column's DDL still lives in
`artifact-backend-ee/pkg/db/migration/000071_add_parent_project_uid_to_file`.
CE deployments without that migration would see GORM `SELECT` the
column as NULL by default; GORM `INSERT` would error if the column
truly didn't exist in the target DB. Today every live Instill stack
has the EE migration applied (the `file` table only exists via the
shared compose stack), so this is a safe forward step. The follow-up
migration relocation lets CE own the schema end-to-end and removes
this caveat.

## Verification

- [x] `go vet ./...` clean
- [x] `gofmt -l` clean on touched files
- [x] `go test ./pkg/handler/... ./pkg/repository/... ./pkg/types/...` green
- [x] Pre-commit hooks (golangci-lint, go-mod-tidy, trailing whitespace) pass
- [ ] k6 follow-up against agent-backend-ee on the R1 branch — pending
      go.mod bump on artifact-backend-ee + agent-backend-ee after this
      lands and release-please cuts a tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)