### PR TITLE
fix(handler): accept parent_project in UpdateFileAdmin field mask

### DIFF
--- a/pkg/handler/private.go
+++ b/pkg/handler/private.go
@@ -368,6 +368,30 @@ func (h *PrivateHandler) UpdateFileAdmin(ctx context.Context, req *artifactpb.Up
 				updates[repository.FileColumn.Tags] = req.GetFile().GetTags()
 			case "external_metadata":
 				updates[repository.FileColumn.ExternalMetadata] = req.GetFile().GetExternalMetadata()
+			case "parent_project":
+				// Set or clear the file's folder home (single permission
+				// parent under the Folder–File Permission Model). Used by
+				// agent-backend-ee's convert000132 boot-time backfill to
+				// retroactively assign a folder UID to every legacy file
+				// whose parent_project_uid is NULL.
+				//
+				// Empty string in `File.ParentProject` clears the column
+				// (sets parent_project_uid back to NULL); a non-empty
+				// value is parsed as a UUID and stored. A malformed UUID
+				// is rejected at this layer rather than silently dropping
+				// the field — the data plane never gets a chance to
+				// over-restrict files because of caller bugs.
+				parent := req.GetFile().GetParentProject()
+				if parent == "" {
+					updates[repository.FileColumn.ParentProjectUID] = nil
+				} else {
+					projectUID, err := uuid.FromString(parent)
+					if err != nil {
+						return nil, status.Errorf(codes.InvalidArgument,
+							"invalid parent_project UUID %q: %v", parent, err)
+					}
+					updates[repository.FileColumn.ParentProjectUID] = projectUID
+				}
 			}
 		}
 	}

--- a/pkg/repository/file.go
+++ b/pkg/repository/file.go
@@ -303,6 +303,12 @@ type FileColumns struct {
 	Tags             string
 	UsageMetadata    string
 	Visibility       string
+	// ParentProjectUID is the file's folder home (single permission parent
+	// under the Folder–File Permission Model). The column DDL is shipped by
+	// the EE migration `000071_add_parent_project_uid_to_file`; CE owns the
+	// read + (limited) write path. Used by `UpdateFileAdmin` to honour the
+	// `parent_project` field mask path.
+	ParentProjectUID string
 }
 
 // FileColumn is the columns for the file table
@@ -327,6 +333,7 @@ var FileColumn = FileColumns{
 	Tags:             "tags",
 	UsageMetadata:    "usage_metadata",
 	Visibility:       "visibility",
+	ParentProjectUID: "parent_project_uid",
 }
 
 // ConvertingPipeline extracts the conversion pipeline, if present, from the


### PR DESCRIPTION
## Because

\`UpdateFileAdmin\` previously dispatched only \`tags\` and
\`external_metadata\` field-mask paths. Any other path silently fell
through the empty \`switch\` body, and when no path matched at all
the handler returned \`400 InvalidArgument: "no fields to update"\`.

This **blocks agent-backend-ee's R1 boot-time backfill**
(\`convert000132\`) which assigns a folder home
(\`parent_project_uid\`) to every legacy file whose column is still
NULL. The migration sends
\`UpdateMask=["parent_project"]\` via this same \`UpdateFileAdmin\`
RPC. Today every call comes back as 400 and the migration's
per-file partial-failure counter increments — the marker never
lands so the migration re-runs every boot, failing every time.

Surfaced while sweeping the R1 chain locally: my k6 tests didn't
catch this earlier because the local stack's files all came in via
the R1 CreateFile path (which populates the column synchronously),
so \`convert000132\` saw zero candidates and trivially marked itself
complete. The 95+2 prod legacy files with NULL parent are the only
real exerciser of this code path, and they only exist in prod /
d0.

## This commit

- Add \`parent_project\` case to the field-mask switch in
  \`pkg/handler/private.go::UpdateFileAdmin\`, symmetric with
  the existing \`tags\` / \`external_metadata\` paths.
- Add \`ParentProjectUID: "parent_project_uid"\` to the
  \`FileColumn\` map so the handler's update spec stays
  consistent with the sibling entries.

Surface details I encoded intentionally:

- **Empty string clears the column.** Matches the proto oneof
  semantics; useful for the future "move file out of any
  folder" case. No current caller, but the contract is honest.
- **Malformed UUID returns 400.** Prevents a caller bug from
  silently dropping the field and ending up with
  \`parent_project_uid = NULL\` (which the new R1 prefilter
  would interpret as "hide this file from every cascade-based
  listing"). Fail-loud at the API boundary instead.
- **Goes through the existing \`Repository().UpdateFile(uid, updates)\`
  path.** No new write helper; the column DDL lives in the EE
  migration \`000071_add_parent_project_uid_to_file\`, CE owns
  the read + this limited write path. The wider EE
  \`SetParentProjectUID\` stays on the CreateFile flow — that
  path is parallel, not chained.

## Verification

- [x] \`go build ./...\` clean.
- [x] \`go test ./pkg/handler/... ./pkg/repository/...\` clean.
- [x] Pre-commit hooks (golangci-lint, go-mod-tidy, trim ws) pass.

A handler unit test that exercises the new path would require
scaffolding the full service + repository mocks (no existing
\`TestUpdateFileAdmin\` to extend); the \`convert000132\` integration
path is the supported assertion surface for this behaviour. The
end-to-end verification:

1. Merge this PR.
2. Bump artifact-backend pin in artifact-backend-ee (\`go get\`
   the new commit + \`go mod tidy\`).
3. Deploy.
4. agent-backend-ee#649 \`convert000132\` runs at boot → reads
   the ~97 prod files with NULL \`parent_project_uid\` → calls
   \`UpdateFileAdmin(parent_project=<folder_uid>)\` per file →
   handler now writes the column → \`migration_markers\` row
   lands → next boot no-ops cleanly.

## Edition / scope

- CE-only change. Touches \`pkg/handler/private.go\` and
  \`pkg/repository/file.go\`.
- No EE surface, no protobufs change, no \`commander\` reference.
- No autofill surface touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)