### PR TITLE
feat(worker): relay RAG model usage metadata

### DIFF
--- a/cmd/main/main.go
+++ b/cmd/main/main.go
@@ -478,6 +478,7 @@ func newAIClient(ctx context.Context, logger *zap.Logger, storage object.Storage
 			ProjectID: cfg.RAG.Model.VertexAI.ProjectID,
 			Region:    cfg.RAG.Model.VertexAI.Region,
 			SAKey:     cfg.RAG.Model.VertexAI.SAKey,
+			Model:     cfg.RAG.Model.VertexAI.Model,
 		}, storage)
 		if err != nil {
 			logger.Error("Failed to initialize VertexAI client", zap.Error(err))
@@ -492,7 +493,7 @@ func newAIClient(ctx context.Context, logger *zap.Logger, storage object.Storage
 		}
 	} else if cfg.RAG.Model.Gemini.APIKey != "" {
 		// Fallback to Gemini API client if VertexAI not configured
-		geminiClient, err := gemini.NewClient(ctx, cfg.RAG.Model.Gemini.APIKey)
+		geminiClient, err := gemini.NewClientWithModel(ctx, cfg.RAG.Model.Gemini.APIKey, cfg.RAG.Model.Gemini.Model)
 		if err != nil {
 			logger.Error("Failed to initialize Gemini client", zap.Error(err))
 		} else {

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -195,16 +195,16 @@ func main() {
 	w.RegisterActivity(cw.GetFilesBatchActivity)    // Retrieve multiple files from MinIO (parallel)
 
 	// Media processing
-	w.RegisterActivity(cw.GetMediaDurationActivity)  // Probe media duration with ffprobe
-	w.RegisterActivity(cw.SplitMediaChunksActivity)  // Split long media into physical chunks
+	w.RegisterActivity(cw.GetMediaDurationActivity) // Probe media duration with ffprobe
+	w.RegisterActivity(cw.SplitMediaChunksActivity) // Split long media into physical chunks
 
 	// Hybrid two-pass audio/visual processing
-	w.RegisterActivity(cw.ExtractAudioActivity)      // Extract audio track from video via FFmpeg
-	w.RegisterActivity(cw.UploadToGCSActivity)       // Upload file from MinIO to GCS
-	w.RegisterActivity(cw.TranscribeAudioActivity)   // Transcribe audio via ConvertAudioDirect
-	w.RegisterActivity(cw.DeleteFromGCSActivity)     // Clean up GCS temp files
-	w.RegisterActivity(cw.ReadMinIOFileActivity)     // Read text file from MinIO
-	w.RegisterActivity(cw.WriteMinIOFileActivity)    // Write/overwrite text file in MinIO
+	w.RegisterActivity(cw.ExtractAudioActivity)    // Extract audio track from video via FFmpeg
+	w.RegisterActivity(cw.UploadToGCSActivity)     // Upload file from MinIO to GCS
+	w.RegisterActivity(cw.TranscribeAudioActivity) // Transcribe audio via ConvertAudioDirect
+	w.RegisterActivity(cw.DeleteFromGCSActivity)   // Clean up GCS temp files
+	w.RegisterActivity(cw.ReadMinIOFileActivity)   // Read text file from MinIO
+	w.RegisterActivity(cw.WriteMinIOFileActivity)  // Write/overwrite text file in MinIO
 
 	// File status management
 	w.RegisterActivity(cw.GetFileStatusActivity)    // Retrieve current file processing status
@@ -293,10 +293,10 @@ func main() {
 	w.RegisterActivity(cw.DeleteCacheActivity)      // Clean up AI cache after processing
 
 	// Content and Summary Processing Phase - Composite activities (flattened from child workflows)
-	w.RegisterActivity(cw.ProcessContentActivity)        // Complete content processing: markdown conversion → save to DB
-	w.RegisterActivity(cw.ProcessSummaryActivity)        // Complete summary processing: generate → save to DB
-	w.RegisterActivity(cw.ApplyPatchToContentActivity)   // Apply user-submitted patch.md to freshly generated content via LLM merge
-	w.RegisterActivity(cw.ReadExistingContentActivity)  // Load existing content.md from MinIO for patch-only fast path
+	w.RegisterActivity(cw.ProcessContentActivity)      // Complete content processing: markdown conversion → save to DB
+	w.RegisterActivity(cw.ProcessSummaryActivity)      // Complete summary processing: generate → save to DB
+	w.RegisterActivity(cw.ApplyPatchToContentActivity) // Apply user-submitted patch.md to freshly generated content via LLM merge
+	w.RegisterActivity(cw.ReadExistingContentActivity) // Load existing content.md from MinIO for patch-only fast path
 
 	// Per-Batch Chunked Conversion Activities (for large files that exceed single-shot limits)
 	w.RegisterActivity(cw.GetPageCountActivity)         // Query cached document for total page count
@@ -323,7 +323,7 @@ func main() {
 
 	// ===== Cleanup Activities =====
 	w.RegisterActivity(cw.CleanupExpiredGCSFilesActivity)      // Scan and delete expired GCS files from bucket and Redis
-	w.RegisterActivity(cw.CleanupExpiredObjectRecordsActivity)  // Hard-delete expired object DB records (blobs already removed by MinIO ILM)
+	w.RegisterActivity(cw.CleanupExpiredObjectRecordsActivity) // Hard-delete expired object DB records (blobs already removed by MinIO ILM)
 
 	if err := w.Start(); err != nil {
 		logger.Fatal(fmt.Sprintf("Unable to start worker: %s", err))
@@ -552,6 +552,7 @@ func newAIClient(ctx context.Context, logger *zap.Logger, storage object.Storage
 			ProjectID: cfg.RAG.Model.VertexAI.ProjectID,
 			Region:    cfg.RAG.Model.VertexAI.Region,
 			SAKey:     cfg.RAG.Model.VertexAI.SAKey,
+			Model:     cfg.RAG.Model.VertexAI.Model,
 		}, storage)
 		if err != nil {
 			logger.Error("Failed to initialize VertexAI client", zap.Error(err))
@@ -566,7 +567,7 @@ func newAIClient(ctx context.Context, logger *zap.Logger, storage object.Storage
 		}
 	} else if cfg.RAG.Model.Gemini.APIKey != "" {
 		// Fallback to Gemini API client if VertexAI not configured
-		geminiClient, err := gemini.NewClient(ctx, cfg.RAG.Model.Gemini.APIKey)
+		geminiClient, err := gemini.NewClientWithModel(ctx, cfg.RAG.Model.Gemini.APIKey, cfg.RAG.Model.Gemini.Model)
 		if err != nil {
 			logger.Error("Failed to initialize Gemini client", zap.Error(err))
 		} else {

--- a/config/config.go
+++ b/config/config.go
@@ -180,6 +180,7 @@ type ModelConfig struct {
 // GeminiConfig defines the configuration for Gemini AI
 type GeminiConfig struct {
 	APIKey string `koanf:"apikey"`
+	Model  string `koanf:"model"`
 }
 
 // OpenAIConfig defines the configuration for OpenAI
@@ -192,6 +193,7 @@ type VertexAIConfig struct {
 	ProjectID string `koanf:"projectid"`
 	Region    string `koanf:"region"`
 	SAKey     string `koanf:"sakey"` // JSON string of service account key (base64-encoded in env vars)
+	Model     string `koanf:"model"`
 }
 
 // GCSConfig defines the configuration for Google Cloud Storage as an object storage backend

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -119,7 +119,9 @@ rag:
       projectid:
       region:
       sakey: # JSON string of service account key (base64-encoded)
+      model: gemini-3.1-pro-preview
     gemini:
       apikey:
+      model: gemini-3.1-pro-preview
     openai:
       apikey:

--- a/docs/rag-indexing.md
+++ b/docs/rag-indexing.md
@@ -15,7 +15,7 @@ flowchart TD
     AudioOnly -->|Yes| GCSAudio["Upload to GCS → ConvertAudioDirect"]
     AudioOnly -->|No| HybridSplit["Extract Audio + Split Video"]
     HybridSplit --> AudioBranch["Audio: GCS → ConvertAudioDirect"]
-    HybridSplit --> VisualBranch["Visual: Cache Chunks → Visual-Only Batches"]
+    HybridSplit --> VisualBranch["Visual: GCS → ConvertVideoRange"]
     AudioBranch --> Merge["Merge Audio + Visual by Timestamp"]
     VisualBranch --> Merge
     Cache --> Convert["AI Content Conversion"]
@@ -34,7 +34,7 @@ flowchart TD
 | **Temporal** | Orchestrates the workflow as activities with retries and timeouts |
 | **MinIO** | Stores original files, standardized files, converted content, and temp chunks |
 | **PostgreSQL** | Tracks file metadata, processing status, converted files, and chunk records |
-| **Gemini** | AI model (`gemini-3.1-pro-preview`) for multimodal content extraction, speaker identification, and summary generation |
+| **Gemini / Vertex AI** | AI model for multimodal content extraction and summary generation. The active model is selected by `rag.model.vertexai.model` or `rag.model.gemini.model`; media and embedding-adjacent flows stay on their dedicated routes. |
 | **Vertex AI Cache** | Caches uploaded files in Gemini context for efficient multi-batch access |
 | **Milvus** | Vector database storing embeddings for semantic search |
 | **ffmpeg / ffprobe** | Media duration probing, physical splitting, and lossless audio extraction |
@@ -115,7 +115,7 @@ For media files, `ffprobe` extracts the exact duration before any AI processing.
 
 ### Phase 4: AI Content Conversion
 
-All file types (documents, images, audio, video) use `gemini-3.1-pro-preview` for content extraction and summary generation.
+File types use the configured Gemini model (`rag.model.vertexai.model` or `rag.model.gemini.model`, default `gemini-3.1-pro-preview`) for content extraction and summary generation. Deployments may provide modality-specific AI clients, but audio/video remain on the dedicated media route.
 
 #### Short Path (Documents & Images)
 
@@ -164,9 +164,9 @@ All video files use a **hybrid two-pass architecture** that separates audio and 
 flowchart TD
     Split["1. SplitMediaChunksActivity<br/>(ffmpeg -c copy, 30s overlap)"]
     Extract["1b. ExtractAudioActivity<br/>(ffmpeg lossless audio extraction)"]
-    Split --> CacheAll["2a. CacheFileContextActivity × N chunks<br/>(all concurrent)"]
+    Split --> UploadVisual["2a. UploadToGCSActivity × N chunks<br/>(all concurrent)"]
     Extract --> UploadGCS["2b. UploadToGCSActivity<br/>(audio → GCS)"]
-    CacheAll --> Speakers["2c. IdentifySpeakersActivity<br/>(from chunk 0 cache)"]
+    UploadVisual --> Speakers["2c. IdentifySpeakersActivity<br/>(from chunk 0 video URI)"]
     UploadGCS --> AudioTranscribe["2d. TranscribeAudioActivity<br/>(ConvertAudioDirect, concurrent with visual)"]
     Speakers --> VisualBatches["2e. ConvertBatchActivity × all segments<br/>(visual-only mode, concurrent)"]
     AudioTranscribe --> Merge["3. mergeAudioAndVisual<br/>(interleave by timestamp)"]
@@ -184,7 +184,7 @@ flowchart TD
 
 **Visual branch (concurrent):**
 
-1. Physical chunks are cached and batched as before, but with `VisualOnly: true` on each `ConvertBatchActivity`. This uses a visual-only prompt that produces only `[Video:]` entries with rich visual descriptions (`[Location:]`, `[Image:]`, `[Chart:]`, `[Diagram:]`, `[Icon:]`, `[Logo:]` sub-tags). No `[Audio:]` or `[Sound:]` tags are generated.
+1. Physical chunks are uploaded to GCS and processed with `ConvertVideoRange` through `ConvertBatchActivity` with `VisualOnly: true`. This uses a visual-only prompt that produces only `[Video:]` entries with rich visual descriptions (`[Location:]`, `[Image:]`, `[Chart:]`, `[Diagram:]`, `[Icon:]`, `[Logo:]` sub-tags). No `[Audio:]` or `[Sound:]` tags are generated.
 2. `SaveAssembledContentActivity` handles timestamp offsetting and overlap trimming as before.
 
 **Merge:**

--- a/pkg/ai/gemini/cache.go
+++ b/pkg/ai/gemini/cache.go
@@ -34,7 +34,7 @@ func (c *Client) CreateCache(ctx context.Context, files []ai.FileContent, ttl ti
 		displayName = fmt.Sprintf("cache-%s", files[0].FileDisplayName)
 	}
 
-	output, err := c.createBatchCache(ctx, GetModel(), files, ttl, displayName)
+	output, err := c.createBatchCache(ctx, c.model, files, ttl, displayName)
 	if err != nil {
 		return nil, errorsx.AddMessage(err, "Unable to optimize file processing. The file will be processed without optimization.")
 	}

--- a/pkg/ai/gemini/client.go
+++ b/pkg/ai/gemini/client.go
@@ -16,10 +16,15 @@ import (
 // Client implements the ai.Client interface for Gemini
 type Client struct {
 	client *genai.Client
+	model  string
 }
 
 // NewClient creates a new Gemini AI client
 func NewClient(ctx context.Context, apiKey string) (*Client, error) {
+	return NewClientWithModel(ctx, apiKey, "")
+}
+
+func NewClientWithModel(ctx context.Context, apiKey, model string) (*Client, error) {
 	if apiKey == "" {
 		err := errorsx.ErrInvalidArgument
 		return nil, errorsx.AddMessage(err, "AI client configuration is missing. Please contact your administrator.")
@@ -36,8 +41,13 @@ func NewClient(ctx context.Context, apiKey string) (*Client, error) {
 		)
 	}
 
+	if model == "" {
+		model = DefaultModel
+	}
+
 	return &Client{
 		client: client,
+		model:  model,
 	}, nil
 }
 
@@ -82,7 +92,7 @@ func (c *Client) CountTokens(ctx context.Context, content []byte, fileType artif
 	}
 
 	// Count tokens using the Gemini API
-	resp, err := c.client.Models.CountTokens(ctx, DefaultModel, contents, nil)
+	resp, err := c.client.Models.CountTokens(ctx, c.model, contents, nil)
 	if err != nil {
 		return 0, nil, errorsx.AddMessage(
 			fmt.Errorf("failed to count tokens: %w", err),

--- a/pkg/ai/gemini/conversion.go
+++ b/pkg/ai/gemini/conversion.go
@@ -121,7 +121,7 @@ func (c *Client) convertToMarkdownWithoutCache(ctx context.Context, content []by
 
 	// Generate content without cache
 	config := createGenerateContentConfig("")
-	return c.generateContentAndExtractMarkdown(ctx, GetModel(), contents, config, nil)
+	return c.generateContentAndExtractMarkdown(ctx, c.model, contents, config, nil)
 }
 
 // convertToMarkdownWithCache converts unstructured data to Markdown using a pre-existing cached context
@@ -149,7 +149,7 @@ func (c *Client) convertToMarkdownWithCache(ctx context.Context, cacheName, prom
 
 	// Generate content using cached context
 	config := createGenerateContentConfig(cacheName)
-	return c.generateContentAndExtractMarkdown(ctx, GetModel(), contents, config, &cacheName)
+	return c.generateContentAndExtractMarkdown(ctx, c.model, contents, config, &cacheName)
 }
 
 // generateContentAndExtractMarkdown is a common helper that calls Gemini API and extracts markdown

--- a/pkg/repository/file.go
+++ b/pkg/repository/file.go
@@ -273,9 +273,11 @@ type ExtraMetaData struct {
 	DurationSeconds int32 `json:"duration_seconds,omitempty"`
 }
 
-// UsageMetadata stores AI usage metadata from content, summary, and embedding generation
-// Format: {"content": {...}, "summary": {...}, "embedding": {...}}
+// UsageMetadata stores AI usage metadata from cache creation, content, summary,
+// and embedding generation.
+// Format: {"cache": {...}, "content": {...}, "summary": {...}, "embedding": {...}}
 type UsageMetadata struct {
+	Cache     map[string]interface{} `json:"cache,omitempty"`
 	Content   map[string]interface{} `json:"content,omitempty"`
 	Summary   map[string]interface{} `json:"summary,omitempty"`
 	Embedding map[string]interface{} `json:"embedding,omitempty"`

--- a/pkg/worker/cache_usage_test.go
+++ b/pkg/worker/cache_usage_test.go
@@ -1,0 +1,22 @@
+package worker
+
+import "testing"
+
+type cachedContentUsageForTest struct {
+	TotalTokenCount int32 `json:"totalTokenCount,omitempty"`
+}
+
+func TestAggregateCacheUsageMetadata(t *testing.T) {
+	got := aggregateCacheUsageMetadata(
+		map[string]interface{}{"totalTokenCount": float64(1200)},
+		&cachedContentUsageForTest{TotalTokenCount: 300},
+	)
+
+	m, ok := got.(map[string]interface{})
+	if !ok {
+		t.Fatalf("aggregateCacheUsageMetadata returned %T, want map[string]interface{}", got)
+	}
+	if total := toInt64(m["totalTokenCount"]); total != 1500 {
+		t.Fatalf("totalTokenCount = %d, want 1500", total)
+	}
+}

--- a/pkg/worker/chunked_conversion_test.go
+++ b/pkg/worker/chunked_conversion_test.go
@@ -474,6 +474,13 @@ func TestAggregateBatchUsage(t *testing.T) {
 			"totalTokenCount":         int64(300),
 			"cachedContentTokenCount": int64(50),
 			"callCount":               2,
+			"promptTokensDetails": []interface{}{
+				map[string]interface{}{"modality": "AUDIO", "tokenCount": int64(70)},
+				map[string]interface{}{"modality": "TEXT", "tokenCount": int64(30)},
+			},
+			"candidatesTokensDetails": []interface{}{
+				map[string]interface{}{"modality": "TEXT", "tokenCount": int64(200)},
+			},
 		},
 		1: {
 			"promptTokenCount":        int64(150),
@@ -481,6 +488,12 @@ func TestAggregateBatchUsage(t *testing.T) {
 			"totalTokenCount":         int64(400),
 			"cachedContentTokenCount": int64(75),
 			"callCount":               3,
+			"promptTokensDetails": []interface{}{
+				map[string]interface{}{"modality": "AUDIO", "tokenCount": int64(120)},
+			},
+			"cacheTokensDetails": []interface{}{
+				map[string]interface{}{"modality": "AUDIO", "tokenCount": int64(75)},
+			},
 		},
 	}
 
@@ -490,6 +503,20 @@ func TestAggregateBatchUsage(t *testing.T) {
 	c.Assert(result["totalTokenCount"], qt.Equals, int64(700))
 	c.Assert(result["cachedContentTokenCount"], qt.Equals, int64(125))
 	c.Assert(result["callCount"], qt.Equals, int64(5))
+	c.Assert(modalityTokenCountFromResult(result, "promptTokensDetails", "AUDIO"), qt.Equals, int64(190))
+	c.Assert(modalityTokenCountFromResult(result, "promptTokensDetails", "TEXT"), qt.Equals, int64(30))
+	c.Assert(modalityTokenCountFromResult(result, "candidatesTokensDetails", "TEXT"), qt.Equals, int64(200))
+	c.Assert(modalityTokenCountFromResult(result, "cacheTokensDetails", "AUDIO"), qt.Equals, int64(75))
+}
+
+func modalityTokenCountFromResult(result map[string]interface{}, key, modality string) int64 {
+	items, _ := result[key].([]map[string]interface{})
+	for _, item := range items {
+		if item["modality"] == modality {
+			return item["tokenCount"].(int64)
+		}
+	}
+	return 0
 }
 
 func TestAggregateBatchUsage_Empty(t *testing.T) {

--- a/pkg/worker/main.go
+++ b/pkg/worker/main.go
@@ -65,10 +65,10 @@ const (
 // These are used by ProcessContentActivity (single-shot only) and ProcessSummaryActivity.
 // The per-batch chunked conversion is handled by separate Temporal activities with their own timeouts.
 const (
-	AIProcessingMinTimeout     = 15 * time.Minute  // Enough for single-shot + without-cache fallback
-	AIProcessingMaxTimeout     = 2 * time.Hour     // For very large single-shot attempts; chunked path uses profile.ActivityTimeout
-	AIProcessingBaseTimeout    = 5 * time.Minute   // Fixed overhead: cache creation, GCS upload, retries
-	AIProcessingBytesPerSecond = 20 * 1024         // ~20KB/sec: dense PDFs (financial, legal) process much slower than simple text
+	AIProcessingMinTimeout     = 15 * time.Minute // Enough for single-shot + without-cache fallback
+	AIProcessingMaxTimeout     = 2 * time.Hour    // For very large single-shot attempts; chunked path uses profile.ActivityTimeout
+	AIProcessingBaseTimeout    = 5 * time.Minute  // Fixed overhead: cache creation, GCS upload, retries
+	AIProcessingBytesPerSecond = 20 * 1024        // ~20KB/sec: dense PDFs (financial, legal) process much slower than simple text
 )
 
 // Step-level timeout constants for the fallback chain inside ProcessContentActivity.
@@ -85,7 +85,7 @@ const (
 // When single-shot conversion hits DEADLINE_EXCEEDED, the document is split into
 // page-range chunks and each chunk is converted independently using the existing cache.
 const (
-	ChunkedConversionMinChunkPages   = 5  // Minimum chunk size for adaptive retry
+	ChunkedConversionMinChunkPages   = 5 // Minimum chunk size for adaptive retry
 	ChunkedConversionPageCountPrompt = "How many pages does this document have? Respond with ONLY the number, nothing else."
 	RateLimitCooldown                = 60 * time.Second // Sleep before batch start and between retry rounds to let API quota recover
 )
@@ -95,10 +95,10 @@ const (
 // Videos exceeding MaxVideoChunkDuration are physically split into chunks using
 // ffmpeg, each processed independently through the existing cache+batch pipeline.
 const (
-	MaxVideoChunkDuration    = 30 * time.Minute // Gemini limit ~45 min for video with audio; 30 min gives safety margin
-	MaxAudioChunkDuration    = 8 * time.Hour    // Gemini limit ~9.5 hours for audio-only
-	ChunkOverlap             = 60 * time.Second // Overlap between adjacent chunks to avoid boundary content loss
-	SegmentOverlapLookback   = 15 * time.Second // Extra API window before a non-first segment's logical start, so the model assigns accurate timestamps to boundary audio that can then be deterministically clipped
+	MaxVideoChunkDuration  = 30 * time.Minute // Gemini limit ~45 min for video with audio; 30 min gives safety margin
+	MaxAudioChunkDuration  = 8 * time.Hour    // Gemini limit ~9.5 hours for audio-only
+	ChunkOverlap           = 60 * time.Second // Overlap between adjacent chunks to avoid boundary content loss
+	SegmentOverlapLookback = 15 * time.Second // Extra API window before a non-first segment's logical start, so the model assigns accurate timestamps to boundary audio that can then be deterministically clipped
 )
 
 // BatchProfile holds per-file-type tuning parameters for the concurrent batch
@@ -492,6 +492,8 @@ type PostFileCompletionFn func(_ workflow.Context, file *repository.FileModel, e
 // if the corresponding activity didn't complete or didn't produce usage data
 // (e.g., OpenAI pipeline route, or the activity failed before LLM call).
 type FileProcessingUsageData struct {
+	CacheUsageMetadata     any    // From CacheFileContextActivity (nil if caching was skipped or failed)
+	CacheModel             string // Model used for cached-content creation
 	ContentUsageMetadata   any    // From ProcessContentActivity (nil if content activity didn't complete)
 	ContentModel           string // Model used for content generation (e.g., "gemini-2.0-flash-001")
 	SummaryUsageMetadata   any    // From ProcessSummaryActivity (nil if summary activity didn't complete)
@@ -531,14 +533,14 @@ type Worker struct {
 	aiClient ai.Client // AI client (can be single or composite with routing capabilities)
 	log      *zap.Logger
 
-	postFileCompletion    PostFileCompletionFn
-	postFileFailure       PostFileFailureFn
-	postContentConversion PostContentConversionFn
-	postStandardization   PostStandardizationFn
-	postSummaryConversion PostSummaryConversionFn
-	generateContentPrompt  string            // Default prompt for AI content generation (backward compat)
-	generateContentPrompts map[string]string // Per-modality prompts: "document", "image", "video", "audio"
-	generateSummaryPrompt  string            // Prompt for AI summary generation
+	postFileCompletion     PostFileCompletionFn
+	postFileFailure        PostFileFailureFn
+	postContentConversion  PostContentConversionFn
+	postStandardization    PostStandardizationFn
+	postSummaryConversion  PostSummaryConversionFn
+	generateContentPrompt  string               // Default prompt for AI content generation (backward compat)
+	generateContentPrompts map[string]string    // Per-modality prompts: "document", "image", "video", "audio"
+	generateSummaryPrompt  string               // Prompt for AI summary generation
 	aiClientOverrides      map[string]ai.Client // Per-modality AI client overrides
 }
 

--- a/pkg/worker/process_file_activity.go
+++ b/pkg/worker/process_file_activity.go
@@ -351,6 +351,7 @@ type UpdateConversionMetadataActivityParam struct {
 // UpdateUsageMetadataActivityParam for updating file usage metadata after content/summary/embedding processing
 type UpdateUsageMetadataActivityParam struct {
 	FileUID           types.FileUIDType // File unique identifier
+	CacheMetadata     any               // Usage metadata from cached-content creation
 	ContentMetadata   any               // Usage metadata from content processing (from AI response)
 	SummaryMetadata   any               // Usage metadata from summary processing (from AI response)
 	EmbeddingMetadata any               // Usage metadata from embedding generation (processed characters)
@@ -722,23 +723,37 @@ func (w *Worker) UpdateConversionMetadataActivity(ctx context.Context, param *Up
 func (w *Worker) UpdateUsageMetadataActivity(ctx context.Context, param *UpdateUsageMetadataActivityParam) error {
 	w.log.Info("UpdateUsageMetadataActivity: Storing usage metadata",
 		zap.String("fileUID", param.FileUID.String()),
+		zap.Bool("hasCacheMetadata", param.CacheMetadata != nil),
 		zap.Bool("hasContentMetadata", param.ContentMetadata != nil),
 		zap.Bool("hasSummaryMetadata", param.SummaryMetadata != nil),
 		zap.Bool("hasEmbeddingMetadata", param.EmbeddingMetadata != nil))
 
 	// Early return if all metadata are nil - no need to do a database update
-	if param.ContentMetadata == nil && param.SummaryMetadata == nil && param.EmbeddingMetadata == nil {
+	if param.CacheMetadata == nil && param.ContentMetadata == nil && param.SummaryMetadata == nil && param.EmbeddingMetadata == nil {
 		w.log.Info("UpdateUsageMetadataActivity: Skipping - no usage metadata available yet",
 			zap.String("fileUID", param.FileUID.String()))
 		return nil
 	}
 
 	// Build usage metadata structure
-	// Format: {"content": {...}, "summary": {...}, "embedding": {...}}
+	// Format: {"cache": {...}, "content": {...}, "summary": {...}, "embedding": {...}}
 	usageMetadata := repository.UsageMetadata{
+		Cache:     make(map[string]interface{}),
 		Content:   make(map[string]interface{}),
 		Summary:   make(map[string]interface{}),
 		Embedding: make(map[string]interface{}),
+	}
+
+	// Store cache metadata if available
+	if param.CacheMetadata != nil {
+		if cacheMap, ok := param.CacheMetadata.(map[string]interface{}); ok {
+			usageMetadata.Cache = cacheMap
+		} else {
+			cacheBytes, err := json.Marshal(param.CacheMetadata)
+			if err == nil {
+				_ = json.Unmarshal(cacheBytes, &usageMetadata.Cache)
+			}
+		}
 	}
 
 	// Store content metadata if available
@@ -1844,7 +1859,6 @@ func (w *Worker) CacheFileContextActivity(ctx context.Context, param *CacheFileC
 			CachedContextEnabled: false,
 		}, nil
 	}
-
 	// Check if file type is supported for caching
 	if !filetype.IsFileTypeSupported(param.FileType) {
 		w.log.Info("CacheFileContextActivity: File type not supported for caching",
@@ -1903,6 +1917,15 @@ func (w *Worker) CacheFileContextActivity(ctx context.Context, param *CacheFileC
 		// continue without optimization rather than failing entirely.
 		if strings.Contains(err.Error(), "minimum token count") {
 			w.log.Info("CacheFileContextActivity: File too small for caching, skipping (< 1024 tokens)",
+				zap.String("fileUID", param.FileUID.String()),
+				zap.String("fileType", param.FileType.String()),
+				zap.Error(err))
+			return &CacheFileContextActivityResult{
+				CachedContextEnabled: false,
+			}, nil
+		}
+		if strings.Contains(err.Error(), "cached contexts are not supported") {
+			w.log.Info("CacheFileContextActivity: AI client does not support cached contexts, skipping cache",
 				zap.String("fileUID", param.FileUID.String()),
 				zap.String("fileType", param.FileType.String()),
 				zap.Error(err))
@@ -2284,13 +2307,13 @@ func (w *Worker) ProcessContentActivity(ctx context.Context, param *ProcessConte
 					zap.String("cacheName", param.CacheName),
 					zap.String("client", aiClient.Name()))
 
-			singleShotCtx, singleShotCancel := context.WithTimeout(authCtx, SingleShotConversionTimeout)
-			conversion, err := aiClient.ConvertToMarkdownWithCache(
-				singleShotCtx,
-				param.CacheName,
-				w.getContentPromptForFileType(param.FileType),
-			)
-			singleShotCancel()
+				singleShotCtx, singleShotCancel := context.WithTimeout(authCtx, SingleShotConversionTimeout)
+				conversion, err := aiClient.ConvertToMarkdownWithCache(
+					singleShotCtx,
+					param.CacheName,
+					w.getContentPromptForFileType(param.FileType),
+				)
+				singleShotCancel()
 				if err != nil {
 					logger.Warn("Cached AI conversion failed, will try without cache", zap.Error(err))
 					conversionErr = err
@@ -2315,15 +2338,15 @@ func (w *Worker) ProcessContentActivity(ctx context.Context, param *ProcessConte
 					zap.String("fileType", param.FileType.String()),
 					zap.String("client", aiClient.Name()))
 
-			singleShotCtx, singleShotCancel := context.WithTimeout(authCtx, SingleShotConversionTimeout)
-			conversion, err := aiClient.ConvertToMarkdownWithoutCache(
-				singleShotCtx,
-				rawFileContent,
-				param.FileType,
-				param.FileDisplayName,
-				w.getContentPromptForFileType(param.FileType),
-			)
-			singleShotCancel()
+				singleShotCtx, singleShotCancel := context.WithTimeout(authCtx, SingleShotConversionTimeout)
+				conversion, err := aiClient.ConvertToMarkdownWithoutCache(
+					singleShotCtx,
+					rawFileContent,
+					param.FileType,
+					param.FileDisplayName,
+					w.getContentPromptForFileType(param.FileType),
+				)
+				singleShotCancel()
 				if err != nil {
 					logger.Error("AI conversion without cache failed", zap.Error(err))
 					conversionErr = err
@@ -2578,9 +2601,9 @@ func formatAugmentedEntities(entities []EntityTag) string {
 	// Walk the joined string rune-by-rune, remembering the last "; "
 	// boundary we saw; stop at the cap.
 	var (
-		runeCount  int
-		lastCut    = -1
-		prevSemi   = false
+		runeCount int
+		lastCut   = -1
+		prevSemi  = false
 	)
 	for i, r := range out {
 		if runeCount >= augmentedChunkMaxRunes {
@@ -2856,11 +2879,12 @@ func (w *Worker) ProcessSummaryActivity(ctx context.Context, param *ProcessSumma
 
 		// Try AI client with cache first (if available)
 		if param.CacheName != "" {
+			aiClient := w.getAIClientForFileType(fileType)
 			logger.Info("Attempting AI summarization with cache",
 				zap.String("cacheName", param.CacheName),
-				zap.String("client", w.aiClient.Name()))
+				zap.String("client", aiClient.Name()))
 
-			conversion, err := w.aiClient.ConvertToMarkdownWithCache(authCtx, param.CacheName, summaryPrompt)
+			conversion, err := aiClient.ConvertToMarkdownWithCache(authCtx, param.CacheName, summaryPrompt)
 			if err != nil {
 				logger.Warn("Cached AI summarization failed, will try without cache", zap.Error(err))
 				summarizationErr = err
@@ -2877,9 +2901,10 @@ func (w *Worker) ProcessSummaryActivity(ctx context.Context, param *ProcessSumma
 		if summary == "" {
 			logger.Info("Attempting AI summarization without cache",
 				zap.String("fileType", fileType.String()),
-				zap.String("client", w.aiClient.Name()))
+				zap.String("client", w.getAIClientForFileType(fileType).Name()))
 
-			conversion, err := w.aiClient.ConvertToMarkdownWithoutCache(
+			aiClient := w.getAIClientForFileType(fileType)
+			conversion, err := aiClient.ConvertToMarkdownWithoutCache(
 				authCtx,
 				content,
 				fileType,
@@ -3018,8 +3043,8 @@ func (w *Worker) ProcessSummaryActivity(ctx context.Context, param *ProcessSumma
 
 // SaveEntitiesActivityParam defines input for SaveEntitiesActivity.
 type SaveEntitiesActivityParam struct {
-	KBUID   types.KBUIDType
-	FileUID types.FileUIDType
+	KBUID    types.KBUIDType
+	FileUID  types.FileUIDType
 	Entities []EntityTag
 }
 
@@ -3536,8 +3561,8 @@ func probeMediaDuration(ctx context.Context, content []byte) (float64, error) {
 
 	var (
 		lastErr      error
-		allExitErr   = true              // every failure so far was *exec.ExitError
-		parsedPerQry []string             // raw stdout of each invocation, for error context
+		allExitErr   = true   // every failure so far was *exec.ExitError
+		parsedPerQry []string // raw stdout of each invocation, for error context
 	)
 	for _, q := range queries {
 		out, err := ffprobeRun(ctx, q...)

--- a/pkg/worker/process_file_workflow.go
+++ b/pkg/worker/process_file_workflow.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"reflect"
 	"strings"
 	"time"
 
@@ -29,7 +30,7 @@ import (
 // ProcessFileWorkflow is already in the RUNNING state for the same
 // workflowID (i.e. for the same fileUID, since workflowID is derived
 // from FileUIDs[0]). It wraps errorsx.ErrAlreadyExists so the standard
-// gRPC mapping in x/errors surfaces ``codes.AlreadyExists`` to callers
+// gRPC mapping in x/errors surfaces "codes.AlreadyExists" to callers
 // (HTTP 409 via grpc-gateway).
 //
 // See ARTIFACT-INV-REPROCESS-NO-TERMINATE-RACE in
@@ -721,6 +722,7 @@ func (w *Worker) ProcessFileWorkflow(ctx workflow.Context, param ProcessFileWork
 
 			if err := workflow.ExecuteActivity(ctx, w.UpdateUsageMetadataActivity, &UpdateUsageMetadataActivityParam{
 				FileUID:           fuid,
+				CacheMetadata:     nil,
 				ContentMetadata:   patchResult.UsageMetadata,
 				SummaryMetadata:   summaryResult.UsageMetadata,
 				EmbeddingMetadata: embedResult.UsageMetadata,
@@ -1026,8 +1028,8 @@ func (w *Worker) ProcessFileWorkflow(ctx workflow.Context, param ProcessFileWork
 		// Step 2d-pre: Probe media duration with ffprobe (before cache creation).
 		// For media files, duration must be known locally because long videos
 		// (> MaxVideoChunkDuration) cannot be cached by Gemini at all.
-		fileDurationSec := make(map[string]int32)  // Map fileUID -> media duration in seconds
-		longMediaFiles := make(map[string]bool)     // Files that need physical chunking
+		fileDurationSec := make(map[string]int32) // Map fileUID -> media duration in seconds
+		longMediaFiles := make(map[string]bool)   // Files that need physical chunking
 
 		for _, cr := range stdResults {
 			if !isMediaFileType(cr.effectiveFileType) {
@@ -1157,6 +1159,8 @@ func (w *Worker) ProcessFileWorkflow(ctx workflow.Context, param ProcessFileWork
 
 		workflowFutures := make([]fileWorkflowFutures, len(processingFutures))
 		fileCacheNames := make(map[string]string)
+		fileCacheUsageMetadata := make(map[string]any)
+		fileCacheModels := make(map[string]string)
 
 		// Phase 1: Collect cache names for all files (Gemini only)
 		for _, pf := range processingFutures {
@@ -1176,6 +1180,8 @@ func (w *Worker) ProcessFileWorkflow(ctx workflow.Context, param ProcessFileWork
 			} else if fileCacheResult.CachedContextEnabled {
 				fileCacheName = fileCacheResult.CacheName
 				fileCacheNames[pf.fileUID.String()] = fileCacheName
+				fileCacheUsageMetadata[pf.fileUID.String()] = fileCacheResult.UsageMetadata
+				fileCacheModels[pf.fileUID.String()] = fileCacheResult.Model
 				logger.Info("File cache created",
 					"fileUID", pf.fileUID.String(),
 					"cacheName", fileCacheName)
@@ -1461,224 +1467,312 @@ func (w *Worker) ProcessFileWorkflow(ctx workflow.Context, param ProcessFileWork
 
 			// ───── Normal path: single-shot or batch conversion ─────
 			{
-			needsBatchConversion := false
-			preQueriedPageCount := filePageCounts[wf.fileUID.String()]
+				needsBatchConversion := false
+				preQueriedPageCount := filePageCounts[wf.fileUID.String()]
 
-			if wf.contentFuture == nil {
-				needsBatchConversion = true
-			} else {
-				contentErr = wf.contentFuture.Get(ctx, &contentResult)
-
-				// Check for activity-level post-LLM error: the LLM call succeeded
-				// but post-processing (DB write, MinIO upload) failed. The result
-				// (including UsageMetadata) is still valid for usage tracking.
-				if contentErr == nil && contentResult.Error != "" {
-					contentErr = fmt.Errorf("%s", contentResult.Error)
-				}
-				if contentErr == nil && contentResult.NeedsChunkedConversion {
+				if wf.contentFuture == nil {
 					needsBatchConversion = true
-				}
-			}
-
-			if needsBatchConversion {
-				cacheName := fileCacheNames[wf.fileUID.String()]
-				if cacheName == "" {
-					contentErr = fmt.Errorf("batch conversion requested but no cache available for file %s", wf.fileUID.String())
 				} else {
-					// Only sleep for quota recovery if single-shot was actually attempted
-					if wf.contentFuture != nil {
-						logger.Info("Sleeping before batch conversion to let API quota recover from single-shot attempts",
-							"fileUID", wf.fileUID.String())
-						_ = workflow.Sleep(ctx, RateLimitCooldown)
+					contentErr = wf.contentFuture.Get(ctx, &contentResult)
+
+					// Check for activity-level post-LLM error: the LLM call succeeded
+					// but post-processing (DB write, MinIO upload) failed. The result
+					// (including UsageMetadata) is still valid for usage tracking.
+					if contentErr == nil && contentResult.Error != "" {
+						contentErr = fmt.Errorf("%s", contentResult.Error)
 					}
+					if contentErr == nil && contentResult.NeedsChunkedConversion {
+						needsBatchConversion = true
+					}
+				}
 
-					logger.Info("Starting per-batch chunked conversion",
-						"fileUID", wf.fileUID.String(),
-						"cacheName", cacheName)
+				if needsBatchConversion {
+					cacheName := fileCacheNames[wf.fileUID.String()]
+					if cacheName == "" {
+						contentErr = fmt.Errorf("batch conversion requested but no cache available for file %s", wf.fileUID.String())
+					} else {
+						// Only sleep for quota recovery if single-shot was actually attempted
+						if wf.contentFuture != nil {
+							logger.Info("Sleeping before batch conversion to let API quota recover from single-shot attempts",
+								"fileUID", wf.fileUID.String())
+							_ = workflow.Sleep(ctx, RateLimitCooldown)
+						}
 
-					batchProfile := batchProfile(wf.conversionData.effectiveFileType)
-					fileDuration := time.Duration(fileDurationSec[wf.fileUID.String()]) * time.Second
-					useTimeRange := batchProfile.SegmentDuration > 0 && fileDuration > 0
+						logger.Info("Starting per-batch chunked conversion",
+							"fileUID", wf.fileUID.String(),
+							"cacheName", cacheName)
 
-					// For page-based mode, determine total pages.
-					totalPages := 0
-					if !useTimeRange {
-						totalPages = preQueriedPageCount
-						if totalPages == 0 {
-							pageCountCtx := workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
-								StartToCloseTimeout: 5 * time.Minute,
+						batchProfile := batchProfile(wf.conversionData.effectiveFileType)
+						fileDuration := time.Duration(fileDurationSec[wf.fileUID.String()]) * time.Second
+						useTimeRange := batchProfile.SegmentDuration > 0 && fileDuration > 0
+
+						// For page-based mode, determine total pages.
+						totalPages := 0
+						if !useTimeRange {
+							totalPages = preQueriedPageCount
+							if totalPages == 0 {
+								pageCountCtx := workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
+									StartToCloseTimeout: 5 * time.Minute,
+									RetryPolicy: &temporal.RetryPolicy{
+										InitialInterval:    RetryInitialInterval,
+										BackoffCoefficient: RetryBackoffCoefficient,
+										MaximumInterval:    RetryMaximumIntervalStandard,
+										MaximumAttempts:    3,
+									},
+								})
+								var pgResult GetPageCountActivityResult
+								if pgErr := workflow.ExecuteActivity(pageCountCtx, w.GetPageCountActivity, &GetPageCountActivityParam{
+									CacheName: cacheName,
+									FileType:  wf.conversionData.effectiveFileType,
+								}).Get(ctx, &pgResult); pgErr != nil {
+									contentErr = fmt.Errorf("failed to get page count: %w", pgErr)
+								} else {
+									totalPages = pgResult.PageCount
+								}
+							}
+						}
+
+						if contentErr == nil && (useTimeRange || totalPages > 0) {
+							batchCtx := workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
+								StartToCloseTimeout: batchProfile.ActivityTimeout,
 								RetryPolicy: &temporal.RetryPolicy{
-									InitialInterval:    RetryInitialInterval,
-									BackoffCoefficient: RetryBackoffCoefficient,
-									MaximumInterval:    RetryMaximumIntervalStandard,
-									MaximumAttempts:    3,
+									InitialInterval:    5 * time.Second,
+									BackoffCoefficient: 2.0,
+									MaximumInterval:    120 * time.Second,
+									MaximumAttempts:    5,
 								},
 							})
-							var pgResult GetPageCountActivityResult
-							if pgErr := workflow.ExecuteActivity(pageCountCtx, w.GetPageCountActivity, &GetPageCountActivityParam{
-								CacheName: cacheName,
-								FileType:  wf.conversionData.effectiveFileType,
-							}).Get(ctx, &pgResult); pgErr != nil {
-								contentErr = fmt.Errorf("failed to get page count: %w", pgErr)
-							} else {
-								totalPages = pgResult.PageCount
+
+							workflowRunID := workflow.GetInfo(ctx).WorkflowExecution.RunID
+
+							type batchSlot struct {
+								Index          int
+								StartPage      int
+								EndPage        int
+								StartTimestamp time.Duration
+								EndTimestamp   time.Duration
+								SegmentIndex   int
 							}
-						}
-					}
 
-				if contentErr == nil && (useTimeRange || totalPages > 0) {
-					batchCtx := workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
-						StartToCloseTimeout: batchProfile.ActivityTimeout,
-						RetryPolicy: &temporal.RetryPolicy{
-							InitialInterval:    5 * time.Second,
-							BackoffCoefficient: 2.0,
-							MaximumInterval:    120 * time.Second,
-							MaximumAttempts:    5,
-						},
-					})
-
-						workflowRunID := workflow.GetInfo(ctx).WorkflowExecution.RunID
-
-						type batchSlot struct {
-							Index          int
-							StartPage      int
-							EndPage        int
-							StartTimestamp time.Duration
-							EndTimestamp   time.Duration
-							SegmentIndex   int
-						}
-
-					var allSlots []batchSlot
-					if useTimeRange {
-						segCount := int(math.Ceil(fileDuration.Seconds() / batchProfile.SegmentDuration.Seconds()))
-						for i := 0; i < segCount; i++ {
-							start := time.Duration(i) * batchProfile.SegmentDuration
-							end := start + batchProfile.SegmentDuration
-							if end > fileDuration {
-								end = fileDuration
-							}
-							allSlots = append(allSlots, batchSlot{
-								Index:          i,
-								SegmentIndex:   i + 1,
-								StartTimestamp: start,
-								EndTimestamp:   end,
-							})
-						}
-					} else {
-						idx := 0
-						for start := 1; start <= totalPages; start += batchProfile.PagesPerBatch {
-							end := start + batchProfile.PagesPerBatch - 1
-							if end > totalPages {
-								end = totalPages
-							}
-							allSlots = append(allSlots, batchSlot{Index: idx, StartPage: start, EndPage: end})
-							idx++
-						}
-					}
-
-						completedPaths := make(map[int]string, len(allSlots))
-						completedUsage := make(map[int]map[string]interface{}, len(allSlots))
-						var batchModel string
-
-						isTransientBatchErr := func(err error) (isCacheExp bool, isTransient bool) {
-							var appErr *temporal.ApplicationError
-							if errors.As(err, &appErr) && appErr.Type() == "CacheExpired" {
-								return true, true
-							}
-						msg := err.Error()
-						if strings.Contains(msg, "RESOURCE_EXHAUSTED") || strings.Contains(msg, "429") ||
-							strings.Contains(msg, "transient error retries exhausted") ||
-							strings.Contains(msg, "DEADLINE_EXCEEDED") || strings.Contains(msg, "504") ||
-							strings.Contains(msg, "UNAVAILABLE") || strings.Contains(msg, "503") ||
-							strings.Contains(msg, "document has no pages") ||
-							strings.Contains(msg, "i/o timeout") || strings.Contains(msg, "connection reset") ||
-							strings.Contains(msg, "connection refused") || strings.Contains(msg, "no such host") {
-							return false, true
-						}
-							return false, false
-						}
-
-						runBatchRound := func(slots []batchSlot, cn string) (failed []batchSlot, hasCacheExp bool, permErr error) {
-							selector := workflow.NewSelector(ctx)
-							pending := 0
-
-							for _, slot := range slots {
-								s := slot
-					activityParam := &ConvertBatchActivityParam{
-						CacheName:      cn,
-						StartPage:      s.StartPage,
-						EndPage:        s.EndPage,
-						TotalPages:     totalPages,
-						KBUID:          kbUID,
-						FileUID:        wf.fileUID,
-						WorkflowRunID:  workflowRunID,
-						BatchIndex:     s.Index,
-						ChunkTimeout:   batchProfile.ChunkTimeout,
-						PagesPerChunk:  batchProfile.PagesPerChunk,
-						UseTimeRange:   useTimeRange,
-						StartTimestamp: s.StartTimestamp,
-						EndTimestamp:   s.EndTimestamp,
-						SegmentIndex:   s.SegmentIndex,
-						FileType:       wf.conversionData.effectiveFileType,
-					}
-							future := workflow.ExecuteActivity(batchCtx, w.ConvertBatchActivity, activityParam)
-								selector.AddFuture(future, func(f workflow.Future) {
-									var result ConvertBatchActivityResult
-									if err := f.Get(ctx, &result); err != nil {
-										cacheExp, transient := isTransientBatchErr(err)
-										if transient {
-											failed = append(failed, s)
-											if cacheExp {
-												hasCacheExp = true
-											}
-											logger.Warn("Batch failed with transient error",
-												"fileUID", wf.fileUID.String(),
-												"batchIndex", s.Index,
-												"cacheExpired", cacheExp,
-												"error", err.Error())
-										} else {
-											permErr = fmt.Errorf("batch %d failed: %w", s.Index, err)
-										}
-								} else {
-									completedPaths[s.Index] = result.TempMinIOPath
-									if result.UsageMetadata != nil {
-										completedUsage[s.Index] = result.UsageMetadata
+							var allSlots []batchSlot
+							if useTimeRange {
+								segCount := int(math.Ceil(fileDuration.Seconds() / batchProfile.SegmentDuration.Seconds()))
+								for i := 0; i < segCount; i++ {
+									start := time.Duration(i) * batchProfile.SegmentDuration
+									end := start + batchProfile.SegmentDuration
+									if end > fileDuration {
+										end = fileDuration
 									}
-									if batchModel == "" && result.Model != "" {
-										batchModel = result.Model
+									allSlots = append(allSlots, batchSlot{
+										Index:          i,
+										SegmentIndex:   i + 1,
+										StartTimestamp: start,
+										EndTimestamp:   end,
+									})
+								}
+							} else {
+								idx := 0
+								for start := 1; start <= totalPages; start += batchProfile.PagesPerBatch {
+									end := start + batchProfile.PagesPerBatch - 1
+									if end > totalPages {
+										end = totalPages
+									}
+									allSlots = append(allSlots, batchSlot{Index: idx, StartPage: start, EndPage: end})
+									idx++
+								}
+							}
+
+							completedPaths := make(map[int]string, len(allSlots))
+							completedUsage := make(map[int]map[string]interface{}, len(allSlots))
+							var batchModel string
+
+							isTransientBatchErr := func(err error) (isCacheExp bool, isTransient bool) {
+								var appErr *temporal.ApplicationError
+								if errors.As(err, &appErr) && appErr.Type() == "CacheExpired" {
+									return true, true
+								}
+								msg := err.Error()
+								if strings.Contains(msg, "RESOURCE_EXHAUSTED") || strings.Contains(msg, "429") ||
+									strings.Contains(msg, "transient error retries exhausted") ||
+									strings.Contains(msg, "DEADLINE_EXCEEDED") || strings.Contains(msg, "504") ||
+									strings.Contains(msg, "UNAVAILABLE") || strings.Contains(msg, "503") ||
+									strings.Contains(msg, "document has no pages") ||
+									strings.Contains(msg, "i/o timeout") || strings.Contains(msg, "connection reset") ||
+									strings.Contains(msg, "connection refused") || strings.Contains(msg, "no such host") {
+									return false, true
+								}
+								return false, false
+							}
+
+							runBatchRound := func(slots []batchSlot, cn string) (failed []batchSlot, hasCacheExp bool, permErr error) {
+								selector := workflow.NewSelector(ctx)
+								pending := 0
+
+								for _, slot := range slots {
+									s := slot
+									activityParam := &ConvertBatchActivityParam{
+										CacheName:      cn,
+										StartPage:      s.StartPage,
+										EndPage:        s.EndPage,
+										TotalPages:     totalPages,
+										KBUID:          kbUID,
+										FileUID:        wf.fileUID,
+										WorkflowRunID:  workflowRunID,
+										BatchIndex:     s.Index,
+										ChunkTimeout:   batchProfile.ChunkTimeout,
+										PagesPerChunk:  batchProfile.PagesPerChunk,
+										UseTimeRange:   useTimeRange,
+										StartTimestamp: s.StartTimestamp,
+										EndTimestamp:   s.EndTimestamp,
+										SegmentIndex:   s.SegmentIndex,
+										FileType:       wf.conversionData.effectiveFileType,
+									}
+									future := workflow.ExecuteActivity(batchCtx, w.ConvertBatchActivity, activityParam)
+									selector.AddFuture(future, func(f workflow.Future) {
+										var result ConvertBatchActivityResult
+										if err := f.Get(ctx, &result); err != nil {
+											cacheExp, transient := isTransientBatchErr(err)
+											if transient {
+												failed = append(failed, s)
+												if cacheExp {
+													hasCacheExp = true
+												}
+												logger.Warn("Batch failed with transient error",
+													"fileUID", wf.fileUID.String(),
+													"batchIndex", s.Index,
+													"cacheExpired", cacheExp,
+													"error", err.Error())
+											} else {
+												permErr = fmt.Errorf("batch %d failed: %w", s.Index, err)
+											}
+										} else {
+											completedPaths[s.Index] = result.TempMinIOPath
+											if result.UsageMetadata != nil {
+												completedUsage[s.Index] = result.UsageMetadata
+											}
+											if batchModel == "" && result.Model != "" {
+												batchModel = result.Model
+											}
+										}
+										pending--
+									})
+									pending++
+
+									if pending >= batchProfile.MaxConcurrentBatches {
+										selector.Select(ctx)
 									}
 								}
-									pending--
-								})
-								pending++
-
-								if pending >= batchProfile.MaxConcurrentBatches {
+								for pending > 0 {
 									selector.Select(ctx)
 								}
+								return
 							}
-							for pending > 0 {
-								selector.Select(ctx)
-							}
-							return
-						}
 
-						logger.Info("Phase 1: concurrent batch dispatch",
-							"fileUID", wf.fileUID.String(),
-							"totalBatches", len(allSlots),
-							"maxConcurrent", batchProfile.MaxConcurrentBatches,
-							"useTimeRange", useTimeRange)
-
-						failedSlots, hasCacheExpired, permanentErr := runBatchRound(allSlots, cacheName)
-
-						// Phase 2: retry transient failures (rate-limit and/or cache-expired)
-						if permanentErr == nil && len(failedSlots) > 0 {
-							logger.Info("Phase 2: retrying transient failures",
+							logger.Info("Phase 1: concurrent batch dispatch",
 								"fileUID", wf.fileUID.String(),
-								"failedBatches", len(failedSlots),
-								"hasCacheExpired", hasCacheExpired)
+								"totalBatches", len(allSlots),
+								"maxConcurrent", batchProfile.MaxConcurrentBatches,
+								"useTimeRange", useTimeRange)
 
-							if hasCacheExpired {
-								cacheCtx := workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
+							failedSlots, hasCacheExpired, permanentErr := runBatchRound(allSlots, cacheName)
+
+							// Phase 2: retry transient failures (rate-limit and/or cache-expired)
+							if permanentErr == nil && len(failedSlots) > 0 {
+								logger.Info("Phase 2: retrying transient failures",
+									"fileUID", wf.fileUID.String(),
+									"failedBatches", len(failedSlots),
+									"hasCacheExpired", hasCacheExpired)
+
+								if hasCacheExpired {
+									cacheCtx := workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
+										StartToCloseTimeout: ActivityTimeoutLong,
+										RetryPolicy: &temporal.RetryPolicy{
+											InitialInterval:    RetryInitialInterval,
+											BackoffCoefficient: RetryBackoffCoefficient,
+											MaximumInterval:    RetryMaximumIntervalStandard,
+											MaximumAttempts:    RetryMaximumAttempts,
+										},
+									})
+
+									var freshCacheResult CacheFileContextActivityResult
+									cacheErr := workflow.ExecuteActivity(cacheCtx, w.CacheFileContextActivity, &CacheFileContextActivityParam{
+										FileUID:         wf.fileUID,
+										KBUID:           kbUID,
+										Bucket:          wf.conversionData.effectiveBucket,
+										Destination:     wf.conversionData.effectiveDestination,
+										FileType:        wf.conversionData.effectiveFileType,
+										FileDisplayName: wf.conversionData.fileMetadata.metadata.File.DisplayName,
+										Metadata:        wf.conversionData.fileMetadata.metadata.ExternalMetadata,
+									}).Get(ctx, &freshCacheResult)
+
+									if cacheErr != nil || !freshCacheResult.CachedContextEnabled {
+										permanentErr = fmt.Errorf("failed to refresh cache for retry round: %v", cacheErr)
+									} else {
+										cacheName = freshCacheResult.CacheName
+										fileCacheNames[wf.fileUID.String()] = cacheName
+										fileCacheUsageMetadata[wf.fileUID.String()] = aggregateCacheUsageMetadata(fileCacheUsageMetadata[wf.fileUID.String()], freshCacheResult.UsageMetadata)
+										fileCacheModels[wf.fileUID.String()] = freshCacheResult.Model
+
+										defer func(cn string) {
+											cleanupCtx, _ := workflow.NewDisconnectedContext(ctx)
+											cleanupCtx = workflow.WithActivityOptions(cleanupCtx, workflow.ActivityOptions{
+												StartToCloseTimeout: time.Minute,
+												RetryPolicy: &temporal.RetryPolicy{
+													InitialInterval:    time.Second,
+													BackoffCoefficient: 2.0,
+													MaximumInterval:    30 * time.Second,
+													MaximumAttempts:    3,
+												},
+											})
+											_ = workflow.ExecuteActivity(cleanupCtx, w.DeleteCacheActivity, &DeleteCacheActivityParam{
+												CacheName: cn,
+											}).Get(cleanupCtx, nil)
+										}(cacheName)
+									}
+								}
+
+								if permanentErr == nil {
+									var retryFailed []batchSlot
+									retryFailed, _, permanentErr = runBatchRound(failedSlots, cacheName)
+									if permanentErr == nil && len(retryFailed) > 0 {
+										permanentErr = fmt.Errorf("%d batches still failing after retry round", len(retryFailed))
+									}
+								}
+							}
+
+							if permanentErr != nil {
+								contentErr = permanentErr
+								// Clean up temp files from completed batches
+								if len(completedPaths) > 0 {
+									cleanupCtx, _ := workflow.NewDisconnectedContext(ctx)
+									cleanupCtx = workflow.WithActivityOptions(cleanupCtx, workflow.ActivityOptions{
+										StartToCloseTimeout: time.Minute,
+										RetryPolicy: &temporal.RetryPolicy{
+											InitialInterval:    time.Second,
+											BackoffCoefficient: 2.0,
+											MaximumInterval:    30 * time.Second,
+											MaximumAttempts:    3,
+										},
+									})
+									paths := make([]string, 0, len(completedPaths))
+									for _, p := range completedPaths {
+										paths = append(paths, p)
+									}
+									_ = workflow.ExecuteActivity(cleanupCtx, w.DeleteFilesBatchActivity, &DeleteFilesBatchActivityParam{
+										Bucket:    wf.conversionData.effectiveBucket,
+										FilePaths: paths,
+									}).Get(cleanupCtx, nil)
+								}
+							}
+
+							if contentErr == nil {
+								// Assemble paths in batch index order
+								tempPaths := make([]string, len(allSlots))
+								for idx, path := range completedPaths {
+									tempPaths[idx] = path
+								}
+
+								saveCtx := workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
 									StartToCloseTimeout: ActivityTimeoutLong,
 									RetryPolicy: &temporal.RetryPolicy{
 										InitialInterval:    RetryInitialInterval,
@@ -1688,127 +1782,41 @@ func (w *Worker) ProcessFileWorkflow(ctx workflow.Context, param ProcessFileWork
 									},
 								})
 
-								var freshCacheResult CacheFileContextActivityResult
-								cacheErr := workflow.ExecuteActivity(cacheCtx, w.CacheFileContextActivity, &CacheFileContextActivityParam{
-									FileUID:         wf.fileUID,
-									KBUID:           kbUID,
-									Bucket:          wf.conversionData.effectiveBucket,
-									Destination:     wf.conversionData.effectiveDestination,
-									FileType:        wf.conversionData.effectiveFileType,
-									FileDisplayName: wf.conversionData.fileMetadata.metadata.File.DisplayName,
-									Metadata:        wf.conversionData.fileMetadata.metadata.ExternalMetadata,
-								}).Get(ctx, &freshCacheResult)
-
-								if cacheErr != nil || !freshCacheResult.CachedContextEnabled {
-									permanentErr = fmt.Errorf("failed to refresh cache for retry round: %v", cacheErr)
+								var saveResult SaveAssembledContentActivityResult
+								if saveErr := workflow.ExecuteActivity(saveCtx, w.SaveAssembledContentActivity, &SaveAssembledContentActivityParam{
+									FileUID:        wf.fileUID,
+									KBUID:          kbUID,
+									FileType:       wf.conversionData.effectiveFileType,
+									TempMinIOPaths: tempPaths,
+									IsMedia:        useTimeRange,
+								}).Get(ctx, &saveResult); saveErr != nil {
+									contentErr = fmt.Errorf("failed to assemble batched content: %w", saveErr)
 								} else {
-									cacheName = freshCacheResult.CacheName
-									fileCacheNames[wf.fileUID.String()] = cacheName
+									contentResult.Content = saveResult.Content
+									contentResult.ConvertedFileUID = saveResult.ConvertedFileUID
+									contentResult.ContentBucket = saveResult.ContentBucket
+									contentResult.ContentPath = saveResult.ContentPath
+									contentResult.Length = saveResult.Length
+									contentResult.PageCount = saveResult.PageCount
+									contentResult.PositionData = saveResult.PositionData
+									contentResult.ConvertedType = wf.conversionData.effectiveFileType
+									contentResult.NeedsChunkedConversion = false
+									contentResult.Model = batchModel
 
-									defer func(cn string) {
-										cleanupCtx, _ := workflow.NewDisconnectedContext(ctx)
-										cleanupCtx = workflow.WithActivityOptions(cleanupCtx, workflow.ActivityOptions{
-											StartToCloseTimeout: time.Minute,
-											RetryPolicy: &temporal.RetryPolicy{
-												InitialInterval:    time.Second,
-												BackoffCoefficient: 2.0,
-												MaximumInterval:    30 * time.Second,
-												MaximumAttempts:    3,
-											},
-										})
-										_ = workflow.ExecuteActivity(cleanupCtx, w.DeleteCacheActivity, &DeleteCacheActivityParam{
-											CacheName: cn,
-										}).Get(cleanupCtx, nil)
-									}(cacheName)
+									aggregated := aggregateBatchUsage(completedUsage)
+									contentResult.UsageMetadata = aggregated
+
+									logger.Info("Per-batch chunked conversion completed successfully",
+										"fileUID", wf.fileUID.String(),
+										"pageCount", saveResult.PageCount,
+										"contentLen", len(saveResult.Content),
+										"model", batchModel,
+										"aggregatedUsage", aggregated)
 								}
-							}
-
-							if permanentErr == nil {
-								var retryFailed []batchSlot
-								retryFailed, _, permanentErr = runBatchRound(failedSlots, cacheName)
-								if permanentErr == nil && len(retryFailed) > 0 {
-									permanentErr = fmt.Errorf("%d batches still failing after retry round", len(retryFailed))
-								}
-							}
-						}
-
-						if permanentErr != nil {
-							contentErr = permanentErr
-							// Clean up temp files from completed batches
-							if len(completedPaths) > 0 {
-								cleanupCtx, _ := workflow.NewDisconnectedContext(ctx)
-								cleanupCtx = workflow.WithActivityOptions(cleanupCtx, workflow.ActivityOptions{
-									StartToCloseTimeout: time.Minute,
-									RetryPolicy: &temporal.RetryPolicy{
-										InitialInterval:    time.Second,
-										BackoffCoefficient: 2.0,
-										MaximumInterval:    30 * time.Second,
-										MaximumAttempts:    3,
-									},
-								})
-								paths := make([]string, 0, len(completedPaths))
-								for _, p := range completedPaths {
-									paths = append(paths, p)
-								}
-								_ = workflow.ExecuteActivity(cleanupCtx, w.DeleteFilesBatchActivity, &DeleteFilesBatchActivityParam{
-									Bucket:    wf.conversionData.effectiveBucket,
-									FilePaths: paths,
-								}).Get(cleanupCtx, nil)
-							}
-						}
-
-						if contentErr == nil {
-							// Assemble paths in batch index order
-							tempPaths := make([]string, len(allSlots))
-							for idx, path := range completedPaths {
-								tempPaths[idx] = path
-							}
-
-							saveCtx := workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
-								StartToCloseTimeout: ActivityTimeoutLong,
-								RetryPolicy: &temporal.RetryPolicy{
-									InitialInterval:    RetryInitialInterval,
-									BackoffCoefficient: RetryBackoffCoefficient,
-									MaximumInterval:    RetryMaximumIntervalStandard,
-									MaximumAttempts:    RetryMaximumAttempts,
-								},
-							})
-
-						var saveResult SaveAssembledContentActivityResult
-						if saveErr := workflow.ExecuteActivity(saveCtx, w.SaveAssembledContentActivity, &SaveAssembledContentActivityParam{
-							FileUID:        wf.fileUID,
-							KBUID:          kbUID,
-							FileType:       wf.conversionData.effectiveFileType,
-							TempMinIOPaths: tempPaths,
-							IsMedia:        useTimeRange,
-						}).Get(ctx, &saveResult); saveErr != nil {
-								contentErr = fmt.Errorf("failed to assemble batched content: %w", saveErr)
-							} else {
-								contentResult.Content = saveResult.Content
-								contentResult.ConvertedFileUID = saveResult.ConvertedFileUID
-								contentResult.ContentBucket = saveResult.ContentBucket
-								contentResult.ContentPath = saveResult.ContentPath
-								contentResult.Length = saveResult.Length
-								contentResult.PageCount = saveResult.PageCount
-								contentResult.PositionData = saveResult.PositionData
-								contentResult.ConvertedType = wf.conversionData.effectiveFileType
-								contentResult.NeedsChunkedConversion = false
-								contentResult.Model = batchModel
-
-								aggregated := aggregateBatchUsage(completedUsage)
-								contentResult.UsageMetadata = aggregated
-
-								logger.Info("Per-batch chunked conversion completed successfully",
-									"fileUID", wf.fileUID.String(),
-									"pageCount", saveResult.PageCount,
-									"contentLen", len(saveResult.Content),
-									"model", batchModel,
-									"aggregatedUsage", aggregated)
 							}
 						}
 					}
 				}
-			}
 			} // end normal path block
 
 		postContent:
@@ -1836,13 +1844,13 @@ func (w *Worker) ProcessFileWorkflow(ctx workflow.Context, param ProcessFileWork
 				}
 			}
 
-		// For long media files, processLongMedia already populated summaryResult
-		// directly — skip the future-based summary wait entirely.
-		var summaryErr error
-		if wf.isLongMedia {
-			// summaryResult was populated inside processLongMedia; nothing to wait for.
-			// If processLongMedia failed, contentErr is already set and will be handled below.
-		} else if wf.isOpenAISequential && wf.summaryFutureChan != nil {
+			// For long media files, processLongMedia already populated summaryResult
+			// directly — skip the future-based summary wait entirely.
+			var summaryErr error
+			if wf.isLongMedia {
+				// summaryResult was populated inside processLongMedia; nothing to wait for.
+				// If processLongMedia failed, contentErr is already set and will be handled below.
+			} else if wf.isOpenAISequential && wf.summaryFutureChan != nil {
 				// OpenAI route: Receive the actual summary future from the goroutine
 				logger.Info("OpenAI sequential processing: receiving summary future from channel",
 					"fileUID", wf.fileUID.String())
@@ -1913,6 +1921,8 @@ func (w *Worker) ProcessFileWorkflow(ctx workflow.Context, param ProcessFileWork
 					return
 				}
 				usageData := &FileProcessingUsageData{
+					CacheUsageMetadata:   fileCacheUsageMetadata[wf.fileUID.String()],
+					CacheModel:           fileCacheModels[wf.fileUID.String()],
 					ContentUsageMetadata: contentResult.UsageMetadata,
 					ContentModel:         contentResult.Model,
 					SummaryUsageMetadata: summaryResult.UsageMetadata,
@@ -2167,6 +2177,7 @@ func (w *Worker) ProcessFileWorkflow(ctx workflow.Context, param ProcessFileWork
 			// According to Gemini API docs: https://ai.google.dev/gemini-api/docs/tokens?lang=python
 			if err := workflow.ExecuteActivity(ctx, w.UpdateUsageMetadataActivity, &UpdateUsageMetadataActivityParam{
 				FileUID:           fileUID,
+				CacheMetadata:     fileCacheUsageMetadata[fileUID.String()],
 				ContentMetadata:   contentResult.UsageMetadata,
 				SummaryMetadata:   summaryResult.UsageMetadata,
 				EmbeddingMetadata: embedResult.UsageMetadata,
@@ -2201,6 +2212,8 @@ func (w *Worker) ProcessFileWorkflow(ctx workflow.Context, param ProcessFileWork
 					}
 				}
 				completionUsageData := &FileProcessingUsageData{
+					CacheUsageMetadata:     fileCacheUsageMetadata[fileUID.String()],
+					CacheModel:             fileCacheModels[fileUID.String()],
 					ContentUsageMetadata:   contentResult.UsageMetadata,
 					ContentModel:           contentResult.Model,
 					SummaryUsageMetadata:   summaryResult.UsageMetadata,
@@ -2388,6 +2401,10 @@ func aggregateBatchUsage(batches map[int]map[string]interface{}) map[string]inte
 		totalTokens         int64
 		cachedContentTokens int64
 		callCount           int64
+		promptDetails       map[string]int64
+		cacheDetails        map[string]int64
+		candidateDetails    map[string]int64
+		toolUseDetails      map[string]int64
 	)
 	for _, m := range batches {
 		promptTokens += toInt64(m["promptTokenCount"])
@@ -2395,13 +2412,114 @@ func aggregateBatchUsage(batches map[int]map[string]interface{}) map[string]inte
 		totalTokens += toInt64(m["totalTokenCount"])
 		cachedContentTokens += toInt64(m["cachedContentTokenCount"])
 		callCount += toInt64(m["callCount"])
+		promptDetails = aggregateModalityDetails(promptDetails, m["promptTokensDetails"])
+		cacheDetails = aggregateModalityDetails(cacheDetails, m["cacheTokensDetails"])
+		candidateDetails = aggregateModalityDetails(candidateDetails, m["candidatesTokensDetails"])
+		toolUseDetails = aggregateModalityDetails(toolUseDetails, m["toolUsePromptTokensDetails"])
 	}
-	return map[string]interface{}{
+	out := map[string]interface{}{
 		"promptTokenCount":        promptTokens,
 		"candidatesTokenCount":    candidatesTokens,
 		"totalTokenCount":         totalTokens,
 		"cachedContentTokenCount": cachedContentTokens,
 		"callCount":               callCount,
+	}
+	if details := modalityDetailsToSlice(promptDetails); details != nil {
+		out["promptTokensDetails"] = details
+	}
+	if details := modalityDetailsToSlice(cacheDetails); details != nil {
+		out["cacheTokensDetails"] = details
+	}
+	if details := modalityDetailsToSlice(candidateDetails); details != nil {
+		out["candidatesTokensDetails"] = details
+	}
+	if details := modalityDetailsToSlice(toolUseDetails); details != nil {
+		out["toolUsePromptTokensDetails"] = details
+	}
+	return out
+}
+
+func aggregateModalityDetails(dst map[string]int64, raw any) map[string]int64 {
+	items, ok := raw.([]interface{})
+	if !ok || len(items) == 0 {
+		return dst
+	}
+	if dst == nil {
+		dst = map[string]int64{}
+	}
+	for _, item := range items {
+		m, ok := item.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		modality, _ := m["modality"].(string)
+		if modality == "" {
+			continue
+		}
+		dst[modality] += toInt64(m["tokenCount"])
+	}
+	return dst
+}
+
+func modalityDetailsToSlice(details map[string]int64) []map[string]interface{} {
+	if len(details) == 0 {
+		return nil
+	}
+	out := make([]map[string]interface{}, 0, len(details))
+	for modality, tokenCount := range details {
+		out = append(out, map[string]interface{}{
+			"modality":   modality,
+			"tokenCount": tokenCount,
+		})
+	}
+	return out
+}
+
+func aggregateCacheUsageMetadata(existing, next any) any {
+	if existing == nil {
+		return next
+	}
+	if next == nil {
+		return existing
+	}
+	total := cacheUsageTotalTokenCount(existing) + cacheUsageTotalTokenCount(next)
+	if total == 0 {
+		return existing
+	}
+	return map[string]interface{}{
+		"totalTokenCount": total,
+	}
+}
+
+func cacheUsageTotalTokenCount(v any) int64 {
+	if v == nil {
+		return 0
+	}
+	if m, ok := v.(map[string]interface{}); ok {
+		return toInt64(m["totalTokenCount"])
+	}
+
+	rv := reflect.ValueOf(v)
+	if rv.Kind() == reflect.Pointer {
+		if rv.IsNil() {
+			return 0
+		}
+		rv = rv.Elem()
+	}
+	if rv.Kind() != reflect.Struct {
+		return 0
+	}
+	field := rv.FieldByName("TotalTokenCount")
+	if !field.IsValid() {
+		return 0
+	}
+	switch field.Kind() {
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return field.Int()
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		return int64(field.Uint())
+	default:
+		return 0
 	}
 }
 
@@ -2427,7 +2545,11 @@ func toInt64(v interface{}) int64 {
 // assembled transcript text.
 func (w *Worker) processLongMedia(
 	ctx workflow.Context,
-	logger interface{ Info(string, ...interface{}); Warn(string, ...interface{}); Error(string, ...interface{}) },
+	logger interface {
+		Info(string, ...interface{})
+		Warn(string, ...interface{})
+		Error(string, ...interface{})
+	},
 	wf *fileWorkflowFutures,
 	kbUID types.KBUIDType,
 	contentResult *ProcessContentActivityResult,
@@ -2509,6 +2631,7 @@ func (w *Worker) processLongMedia(
 
 	chunkCacheNames := make([]string, len(splitResult.Chunks))
 	chunkGCSURIs := make([]string, len(splitResult.Chunks))
+	chunkGCSObjectPaths := make([]string, len(splitResult.Chunks))
 	cacheErrs := make([]error, len(splitResult.Chunks))
 	cacheSel := workflow.NewSelector(ctx)
 	cachePending := 0
@@ -2516,29 +2639,50 @@ func (w *Worker) processLongMedia(
 	for ci, chunk := range splitResult.Chunks {
 		i := ci
 		ch := chunk
-		future := workflow.ExecuteActivity(cacheCtx, w.CacheFileContextActivity, &CacheFileContextActivityParam{
-			FileUID:         fileUID,
-			KBUID:           kbUID,
-			Bucket:          cr.effectiveBucket,
-			Destination:     ch.MinIOPath,
-			FileType:        cr.effectiveFileType,
-			FileDisplayName: fmt.Sprintf("%s (chunk %d)", cr.fileMetadata.metadata.File.DisplayName, ch.Index),
-			Metadata:        cr.fileMetadata.metadata.ExternalMetadata,
-		})
-		cacheSel.AddFuture(future, func(f workflow.Future) {
-			var result CacheFileContextActivityResult
-			if err := f.Get(ctx, &result); err != nil {
-				cacheErrs[i] = err
-			} else if !result.CachedContextEnabled {
-				logger.Warn("processLongMedia: Caching unavailable for chunk, proceeding without cache",
-					"chunkIndex", i,
-					"fileType", cr.effectiveFileType.String())
-			} else {
-				chunkCacheNames[i] = result.CacheName
-				chunkGCSURIs[i] = result.GCSURI
-			}
-			cachePending--
-		})
+		if isVideoFileType(cr.effectiveFileType) {
+			future := workflow.ExecuteActivity(cacheCtx, w.UploadToGCSActivity, &UploadToGCSActivityParam{
+				Bucket:     cr.effectiveBucket,
+				SourcePath: ch.MinIOPath,
+				MIMEType:   videoMIMETypeForFileType(cr.effectiveFileType),
+				FileUID:    fileUID.String(),
+			})
+			cacheSel.AddFuture(future, func(f workflow.Future) {
+				var result UploadToGCSActivityResult
+				if err := f.Get(ctx, &result); err != nil {
+					cacheErrs[i] = err
+				} else {
+					chunkGCSURIs[i] = result.GSURI
+					chunkGCSObjectPaths[i] = result.GCSObjectPath
+				}
+				cachePending--
+			})
+		} else {
+			future := workflow.ExecuteActivity(cacheCtx, w.CacheFileContextActivity, &CacheFileContextActivityParam{
+				FileUID:         fileUID,
+				KBUID:           kbUID,
+				Bucket:          cr.effectiveBucket,
+				Destination:     ch.MinIOPath,
+				FileType:        cr.effectiveFileType,
+				FileDisplayName: fmt.Sprintf("%s (chunk %d)", cr.fileMetadata.metadata.File.DisplayName, ch.Index),
+				Metadata:        cr.fileMetadata.metadata.ExternalMetadata,
+			})
+			cacheSel.AddFuture(future, func(f workflow.Future) {
+				var result CacheFileContextActivityResult
+				if err := f.Get(ctx, &result); err != nil {
+					cacheErrs[i] = err
+				} else {
+					chunkGCSURIs[i] = result.GCSURI
+					if !result.CachedContextEnabled {
+						logger.Warn("processLongMedia: Caching unavailable for chunk, proceeding without cache",
+							"chunkIndex", i,
+							"fileType", cr.effectiveFileType.String())
+					} else {
+						chunkCacheNames[i] = result.CacheName
+					}
+				}
+				cachePending--
+			})
+		}
 		cachePending++
 	}
 	for cachePending > 0 {
@@ -2558,6 +2702,20 @@ func (w *Worker) processLongMedia(
 				RetryPolicy:         &temporal.RetryPolicy{InitialInterval: time.Second, BackoffCoefficient: 2.0, MaximumInterval: 30 * time.Second, MaximumAttempts: 3},
 			})
 			_ = workflow.ExecuteActivity(cleanupCtx, w.DeleteCacheActivity, &DeleteCacheActivityParam{CacheName: cacheName}).Get(cleanupCtx, nil)
+		}()
+	}
+	for _, objectPath := range chunkGCSObjectPaths {
+		if objectPath == "" {
+			continue
+		}
+		path := objectPath
+		defer func() {
+			cleanupCtx, _ := workflow.NewDisconnectedContext(ctx)
+			cleanupCtx = workflow.WithActivityOptions(cleanupCtx, workflow.ActivityOptions{
+				StartToCloseTimeout: time.Minute,
+				RetryPolicy:         &temporal.RetryPolicy{InitialInterval: time.Second, BackoffCoefficient: 2.0, MaximumInterval: 30 * time.Second, MaximumAttempts: 3},
+			})
+			_ = workflow.ExecuteActivity(cleanupCtx, w.DeleteFromGCSActivity, &DeleteFromGCSActivityParam{GCSObjectPath: path}).Get(cleanupCtx, nil)
 		}()
 	}
 
@@ -2832,7 +2990,11 @@ func (w *Worker) processLongMedia(
 // and using a single ConvertAudioDirect call instead of the chunked pipeline.
 func (w *Worker) processAudioOnlyLongMedia(
 	ctx workflow.Context,
-	logger interface{ Info(string, ...interface{}); Warn(string, ...interface{}); Error(string, ...interface{}) },
+	logger interface {
+		Info(string, ...interface{})
+		Warn(string, ...interface{})
+		Error(string, ...interface{})
+	},
 	wf *fileWorkflowFutures,
 	kbUID types.KBUIDType,
 	contentResult *ProcessContentActivityResult,


### PR DESCRIPTION
**Because**

- RAG indexing credit must be based on actual Gemini/Vertex token, cache, modality, and embedding usage instead of synthetic page/media counts.

**This commit**

- Carries cache, content, summary, and embedding usage metadata through artifact file processing.
- Aggregates Gemini modality token details across chunked conversions.
- Updates the RAG indexing docs for the current GCS-backed media path.

**Test plan**

- `go test ./pkg/worker -run 'TestAggregateBatchUsage|TestAggregateCacheUsageMetadata'`
- Live agent-backend-ee k6 Gemini text/image/PDF and audio/video credit suites passed before commit.