### PR TITLE
fix(repo): clear content hash on file delete

### DIFF
--- a/pkg/repository/content_sha256_unique_test.go
+++ b/pkg/repository/content_sha256_unique_test.go
@@ -113,6 +113,30 @@ func TestInvariant_CreateFilePopulatesContentSHA256(t *testing.T) {
 	}
 }
 
+// TestInvariant_DeleteFileClearsAssociationContentSHA256 verifies that a
+// soft-deleted file releases the partial unique index slot for re-upload.
+func TestInvariant_DeleteFileClearsAssociationContentSHA256(t *testing.T) {
+	src := readRepoSourceFile(t, "file.go")
+
+	const marker = "func (r *repository) DeleteFileAndDecreaseUsage("
+	idx := strings.Index(src, marker)
+	if idx < 0 {
+		t.Fatalf("DeleteFileAndDecreaseUsage signature not found in file.go")
+	}
+	body := src[idx:]
+	next := strings.Index(body, "\n// GetFileByKBUIDAndFileID")
+	if next > 0 {
+		body = body[:next]
+	}
+
+	if !strings.Contains(body, "tx.Model(&FileKnowledgeBase{})") {
+		t.Error("DeleteFileAndDecreaseUsage must update file_knowledge_base associations")
+	}
+	if !strings.Contains(body, `Update("content_sha256", "")`) {
+		t.Error("DeleteFileAndDecreaseUsage must clear association content_sha256")
+	}
+}
+
 // TestInvariant_ErrDuplicateContentSHA256Defined verifies the sentinel error
 // and helper function exist.
 func TestInvariant_ErrDuplicateContentSHA256Defined(t *testing.T) {

--- a/pkg/repository/file.go
+++ b/pkg/repository/file.go
@@ -335,7 +335,7 @@ var FileColumn = FileColumns{
 	Tags:             "tags",
 	UsageMetadata:    "usage_metadata",
 	Visibility:       "visibility",
-	ParentFolderUID: "parent_folder_uid",
+	ParentFolderUID:  "parent_folder_uid",
 }
 
 // ConvertingPipeline extracts the conversion pipeline, if present, from the
@@ -1579,6 +1579,12 @@ func (r *repository) DeleteFileAndDecreaseUsage(ctx context.Context, fileUID typ
 			Where(whereClause, fileUID).
 			Update(FileColumn.DeleteTime, currentTime).Error; err != nil {
 			return err
+		}
+
+		if err := tx.Model(&FileKnowledgeBase{}).
+			Where("file_uid = ?", fileUID).
+			Update("content_sha256", "").Error; err != nil {
+			return fmt.Errorf("clearing content_sha256 on associations: %w", err)
 		}
 
 		// Decrease usage for all associated KBs


### PR DESCRIPTION
Because soft-deleted file_knowledge_base rows retain content_sha256, the partial per-KB unique index can keep blocking later uploads of identical content even after the original file is deleted.

This commit clears the association content_sha256 during DeleteFileAndDecreaseUsage and pins the invariant with a focused repository test.