### PR TITLE
fix(rag): account input characters for direct Gemini embedding usage

### DIFF
--- a/pkg/ai/gemini/embedding.go
+++ b/pkg/ai/gemini/embedding.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"sync"
 	"time"
+	"unicode/utf8"
 
 	"google.golang.org/genai"
 
@@ -12,6 +13,21 @@ import (
 
 	errorsx "github.com/instill-ai/x/errors"
 )
+
+// embeddingBillableChars returns the number of billable characters to account
+// for one embedded text. It prefers the provider-reported count (the Vertex
+// API populates BillableCharacterCount) and falls back to the UTF-8 character
+// length of the input text when the provider omits it (the direct Gemini API
+// returns no usage Metadata). Gemini embeddings are billed per input
+// character, so the text we actually sent is the authoritative count — this is
+// what keeps file-processing usage faithful instead of collapsing to the flat
+// file-category fallback when no provider metadata is present.
+func embeddingBillableChars(providerBillableChars int32, text string) int32 {
+	if providerBillableChars > 0 {
+		return providerBillableChars
+	}
+	return int32(utf8.RuneCountInString(text))
+}
 
 // EmbedTexts generates embeddings for a batch of texts using Gemini API directly
 //
@@ -174,13 +190,21 @@ func (c *Client) EmbedTexts(ctx context.Context, texts []string, taskType string
 					break
 				}
 
-			// Accumulate processed characters if metadata is available
-			// (Vertex API only — may be nil for direct Gemini API)
+			// Account the characters processed for this text so usage/billing
+			// is faithful. The Vertex API reports BillableCharacterCount, but
+			// the direct Gemini API omits Metadata entirely — in that case fall
+			// back to the input length we actually sent. Gemini embeddings are
+			// billed per input character, so the text we embedded is the
+			// authoritative count when the provider doesn't supply one. Without
+			// this fallback, direct-Gemini embeddings recorded zero usage, which
+			// downstream consumers cannot bill against the real model.
+			var billableChars int32
 			if result.Metadata != nil {
-				mu.Lock()
-				totalProcessedChars += result.Metadata.BillableCharacterCount
-				mu.Unlock()
+				billableChars = result.Metadata.BillableCharacterCount
 			}
+			mu.Lock()
+			totalProcessedChars += embeddingBillableChars(billableChars, txt)
+			mu.Unlock()
 
 			// Success! Store the embedding
 			embedding = emb.Values

--- a/pkg/ai/gemini/embedding_billable_chars_test.go
+++ b/pkg/ai/gemini/embedding_billable_chars_test.go
@@ -1,0 +1,33 @@
+package gemini
+
+import "testing"
+
+// TestEmbeddingBillableChars pins the usage-faithfulness contract for the
+// Gemini embedding path: when the provider reports a billable character count
+// (Vertex API) it is used verbatim; when it does not (the direct Gemini API
+// returns no Metadata, so the count arrives as 0) the activity must fall back
+// to the UTF-8 character length of the input text actually embedded. A zero
+// here is what previously left RAG-indexed files with no embedding usage to
+// bill against, collapsing downstream cost accounting to a flat per-file
+// fallback instead of faithful per-character billing.
+func TestEmbeddingBillableChars(t *testing.T) {
+	cases := []struct {
+		name     string
+		provider int32
+		text     string
+		want     int32
+	}{
+		{"provider count wins when present", 42, "hello", 42},
+		{"falls back to input length when provider omits (direct Gemini)", 0, "hello", 5},
+		{"empty text yields zero", 0, "", 0},
+		{"multibyte counted as characters not bytes", 0, "café—日本語", 8},
+		{"provider count preferred even if smaller than text", 3, "hello world", 3},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := embeddingBillableChars(c.provider, c.text); got != c.want {
+				t.Errorf("embeddingBillableChars(%d, %q) = %d, want %d", c.provider, c.text, got, c.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Because:
- The Gemini embedding path only accumulated processed characters when the provider returned usage metadata, which the **direct Gemini API does not** (only the Vertex API populates `BillableCharacterCount`). Embedding usage therefore came back as zero, leaving downstream cost accounting unable to attribute the embedding model and collapsing it to a flat per-file fallback.

This commit:
- Accounts the UTF-8 character length of each embedded text when the provider omits its own billable-character count, preferring the provider count when present (new `embeddingBillableChars` helper). Gemini embeddings are billed per input character, so the text we sent is the authoritative count when the provider does not supply one.
- Adds `TestEmbeddingBillableChars` covering provider-count, input-length fallback, empty text, and multibyte (characters-not-bytes) cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)