### PR TITLE
perf(files): batch ListFiles enrichment queries (remove N+1 / OR-chain)

### DIFF
--- a/pkg/repository/chunk.go
+++ b/pkg/repository/chunk.go
@@ -387,41 +387,39 @@ func (r *repository) GetTotalTextChunksBySources(ctx context.Context, sources ma
 		return result, nil
 	}
 
-	// Prepare the conditions for the query
-	var conditions []string
-	var values []any
-
-	for _, source := range sources {
-		conditions = append(conditions, "(source_table = ? AND source_uid = ?)")
-		values = append(values, source.SourceTable, source.SourceUID)
+	// Group source_uids by source_table and keep a reverse index from
+	// (table, uid) -> fileUID. Querying `source_table = ? AND source_uid IN ?`
+	// (one query per distinct table, usually one) uses the
+	// (source_table, source_uid, ...) index — replacing the previous giant
+	// `(source_table=? AND source_uid=?) OR ...` chain that PostgreSQL could
+	// not index and which seq-scanned the whole chunk table per call (the
+	// dominant cost of the ListFiles "fetching chunks" enrichment). The
+	// reverse index also drops the old O(sources × results) mapping to O(N).
+	uidsByTable := make(map[types.SourceTableType][]types.SourceUIDType)
+	fileBySource := make(map[types.SourceTableType]map[types.SourceUIDType]types.FileUIDType)
+	for fileUID, source := range sources {
+		uidsByTable[source.SourceTable] = append(uidsByTable[source.SourceTable], source.SourceUID)
+		if fileBySource[source.SourceTable] == nil {
+			fileBySource[source.SourceTable] = make(map[types.SourceUIDType]types.FileUIDType)
+		}
+		fileBySource[source.SourceTable][source.SourceUID] = fileUID
 	}
 
-	// Combine all conditions
-	whereClause := strings.Join(conditions, " OR ")
-
-	// Query to get total tokens grouped by source_table and source_uid
-	var tokenSums []struct {
-		SourceTable types.SourceTableType `gorm:"column:source_table"`
-		SourceUID   types.SourceUIDType   `gorm:"column:source_uid"`
-		TotalTokens int                   `gorm:"column:total_tokens"`
-	}
-
-	err := r.db.WithContext(ctx).Model(&ChunkModel{}).
-		Select("source_table, source_uid, COUNT(*) as total_tokens").
-		Where(whereClause, values...).
-		Group("source_table, source_uid").
-		Find(&tokenSums).Error
-
-	if err != nil {
-		return nil, err
-	}
-
-	// Populate the result map
-	for _, sum := range tokenSums {
-		for fileUID, source := range sources {
-			if source.SourceTable == sum.SourceTable && source.SourceUID == sum.SourceUID {
-				result[fileUID] = sum.TotalTokens
-				break
+	for table, uids := range uidsByTable {
+		var counts []struct {
+			SourceUID types.SourceUIDType `gorm:"column:source_uid"`
+			Total     int                 `gorm:"column:total"`
+		}
+		if err := r.db.WithContext(ctx).Model(&ChunkModel{}).
+			Select("source_uid, COUNT(*) as total").
+			Where("source_table = ? AND source_uid IN ?", table, uids).
+			Group("source_uid").
+			Find(&counts).Error; err != nil {
+			return nil, err
+		}
+		for _, c := range counts {
+			if fileUID, ok := fileBySource[table][c.SourceUID]; ok {
+				result[fileUID] = c.Total
 			}
 		}
 	}

--- a/pkg/repository/enrichment_batching_test.go
+++ b/pkg/repository/enrichment_batching_test.go
@@ -1,0 +1,74 @@
+package repository
+
+import (
+	"context"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/gofrs/uuid"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+
+	"github.com/instill-ai/artifact-backend/pkg/types"
+)
+
+// TestGetTotalTextChunksBySources_Batched pins the OR-chain → indexable-IN
+// rewrite: counts must be grouped per source_uid, scoped by source_table
+// (a chunk in a different source_table must NOT count toward a file), and
+// files with no chunks must be absent from the result. This is the behaviour
+// that the previous `(source_table=? AND source_uid=?) OR …` chain provided —
+// preserved while making the query index-friendly.
+func TestGetTotalTextChunksBySources_Batched(t *testing.T) {
+	c := qt.New(t)
+
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	c.Assert(err, qt.IsNil)
+	// Minimal `chunk` schema — GetTotalTextChunksBySources only references
+	// source_table + source_uid (Select/Where/Group).
+	c.Assert(db.Exec(`CREATE TABLE chunk (uid TEXT, source_table TEXT, source_uid TEXT)`).Error, qt.IsNil)
+
+	repo := &repository{db: db}
+	ctx := context.Background()
+
+	srcA := uuid.Must(uuid.NewV4()) // 2 chunks in converted_file
+	srcB := uuid.Must(uuid.NewV4()) // 3 chunks in converted_file
+	srcC := uuid.Must(uuid.NewV4()) // no chunks
+
+	insert := func(table string, src uuid.UUID) {
+		c.Assert(db.Exec(`INSERT INTO chunk (uid, source_table, source_uid) VALUES (?, ?, ?)`,
+			uuid.Must(uuid.NewV4()).String(), table, src.String()).Error, qt.IsNil)
+	}
+	insert("converted_file", srcA)
+	insert("converted_file", srcA)
+	insert("converted_file", srcB)
+	insert("converted_file", srcB)
+	insert("converted_file", srcB)
+	// A chunk for srcA under a DIFFERENT source_table — must be excluded by
+	// the source_table predicate (would wrongly inflate srcA to 3 if dropped).
+	insert("other_table", srcA)
+
+	fA := uuid.Must(uuid.NewV4())
+	fB := uuid.Must(uuid.NewV4())
+	fC := uuid.Must(uuid.NewV4())
+
+	sources := map[types.FileUIDType]struct {
+		SourceTable types.SourceTableType
+		SourceUID   types.SourceUIDType
+	}{
+		fA: {SourceTable: "converted_file", SourceUID: srcA},
+		fB: {SourceTable: "converted_file", SourceUID: srcB},
+		fC: {SourceTable: "converted_file", SourceUID: srcC},
+	}
+
+	counts, err := repo.GetTotalTextChunksBySources(ctx, sources)
+	c.Assert(err, qt.IsNil)
+	c.Check(counts[fA], qt.Equals, 2, qt.Commentf("source_table predicate must exclude the other_table chunk"))
+	c.Check(counts[fB], qt.Equals, 3)
+	_, hasC := counts[fC]
+	c.Check(hasC, qt.IsFalse, qt.Commentf("a file with no chunks must be absent from the map"))
+
+	// Empty input short-circuits.
+	empty, err := repo.GetTotalTextChunksBySources(ctx, nil)
+	c.Assert(err, qt.IsNil)
+	c.Check(len(empty), qt.Equals, 0)
+}

--- a/pkg/repository/file.go
+++ b/pkg/repository/file.go
@@ -1199,30 +1199,41 @@ func (r *repository) GetContentByFileUIDs(ctx context.Context, files []FileModel
 		SourceTable string
 		SourceUID   types.SourceUIDType
 	})
+	if len(files) == 0 {
+		return result, nil
+	}
+
+	// Batch the CONTENT converted-file lookup into one indexed query
+	// (idx_unique_converted_file_file_uid_type) instead of one
+	// GetConvertedFileByFileUIDAndType per file. A list page of N files was
+	// previously N sequential round-trips — the dominant cost of the
+	// ListFiles "fetching sources" enrichment. Files without a CONTENT
+	// converted record are simply absent from the result map (same skip
+	// semantics as the per-file gorm.ErrRecordNotFound path).
+	fileUIDs := make([]types.FileUIDType, 0, len(files))
 	for _, file := range files {
-		// find the source table and source uid by file uid
-		// All file types now use converted_file as the source after the refactoring
-		// TEXT/MARKDOWN files also have converted file records (pointing to original files)
-		// We specifically need the CONTENT converted file for chunks and tokens
-		convertedFile, err := r.GetConvertedFileByFileUIDAndType(ctx, file.UID, artifactpb.ConvertedFileType_CONVERTED_FILE_TYPE_CONTENT)
-		if err != nil {
-			if errors.Is(err, gorm.ErrRecordNotFound) {
-				// Skip files without converted records
-				continue
-			} else {
-				logger.Error("failed to get converted file by file uid", zap.Error(err))
-				return map[types.FileUIDType]struct {
-					SourceTable string
-					SourceUID   types.SourceUIDType
-				}{}, err
-			}
-		}
-		result[file.UID] = struct {
+		fileUIDs = append(fileUIDs, file.UID)
+	}
+
+	var convertedFiles []ConvertedFileModel
+	where := fmt.Sprintf("%s IN ? AND %s = ?", ConvertedFileColumn.FileUID, ConvertedFileColumn.ConvertedType)
+	if err := r.db.WithContext(ctx).
+		Where(where, fileUIDs, artifactpb.ConvertedFileType_CONVERTED_FILE_TYPE_CONTENT.String()).
+		Find(&convertedFiles).Error; err != nil {
+		logger.Error("failed to batch-get converted files by file uids", zap.Error(err))
+		return map[types.FileUIDType]struct {
+			SourceTable string
+			SourceUID   types.SourceUIDType
+		}{}, err
+	}
+
+	for _, cf := range convertedFiles {
+		result[cf.FileUID] = struct {
 			SourceTable string
 			SourceUID   types.SourceUIDType
 		}{
 			SourceTable: ConvertedFileTableName,
-			SourceUID:   convertedFile.UID,
+			SourceUID:   cf.UID,
 		}
 	}
 


### PR DESCRIPTION
Because:
- `ListFiles` / `ListFilesAdmin` (the Files page path) enriches each page with per-file source + chunk-count data. Two fetchers scaled badly with page size and dominated latency — measured live, a 100-file Document page in Card mode took **3.7–8.8 s and was cancelled by the client** (`"fetching sources/chunks: context canceled"`):
  - `GetContentByFileUIDs` ran **one query per file** (`GetConvertedFileByFileUIDAndType`) — N sequential round-trips ("fetching sources").
  - `GetTotalTextChunksBySources` built a giant `(source_table=? AND source_uid=?) OR …` chain over the `chunk` table — un-indexable, **seq-scans per call** ("fetching chunks").

This commit:
- **`GetContentByFileUIDs`** → one indexed `file_uid IN ? AND converted_type = ?` query (`idx_unique_converted_file_file_uid_type`) for the whole page.
- **`GetTotalTextChunksBySources`** → group source_uids by `source_table` and query `source_table = ? AND source_uid IN ?` (one query per distinct table, usually one), using the `(source_table, source_uid, …)` index; result mapping drops from O(sources × results) to O(N).
- **Behaviour preserved** (same source mapping + chunk counts; files without a source/chunks remain absent), covered by the existing `grpc.js` ListFiles enrichment assertions.
- Adds `TestGetTotalTextChunksBySources_Batched` (per-file counts, source_table scoping, empty-input, missing-file-absent).

Measurement notes: SQL list (~15 ms), `file_type` index (not needed), FGA permission filter (org fast-path; ~424-collection enumeration) were all ruled out — the time was in these two enrichment fetchers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)